### PR TITLE
Rooms JSON API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby IO.read('.ruby-version').chomp
 
+gem 'active_model_serializers'
 gem 'gds-sso'
 gem 'govuk_admin_template'
 gem 'pg', '~> 0.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.6)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.2)
     activejob (5.1.2)
       activesupport (= 5.1.2)
       globalid (>= 0.3.6)
@@ -56,6 +61,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubi (1.6.1)
@@ -88,6 +95,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jsonapi-renderer (0.1.3)
     jwt (1.5.6)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -241,6 +249,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   byebug
   capybara
   factory_girl_rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :require_signin_permission!
+
+  protected
+
+  def authorise_booking_manager!
+    authorise_user!(User::BOOKING_MANAGER)
+  end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -4,10 +4,4 @@ class LocationsController < ApplicationController
   def index
     @locations = current_user.locations.order(:name)
   end
-
-  private
-
-  def authorise_booking_manager!
-    authorise_user!(User::BOOKING_MANAGER)
-  end
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,0 +1,15 @@
+class RoomsController < ApplicationController
+  before_action :authorise_booking_manager!
+
+  def index
+    @rooms = location.rooms.order(:name)
+
+    render json: @rooms
+  end
+
+  private
+
+  def location
+    current_user.locations.find(params[:location_id])
+  end
+end

--- a/app/serializers/room_serializer.rb
+++ b/app/serializers/room_serializer.rb
@@ -1,0 +1,4 @@
+class RoomSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :name, key: :title
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root 'bookings#index'
 
-  resources :locations, only: :index
+  resources :locations, only: :index do
+    resources :rooms, only: :index
+  end
 end

--- a/spec/features/booking_manager_views_their_locations_spec.rb
+++ b/spec/features/booking_manager_views_their_locations_spec.rb
@@ -10,15 +10,6 @@ RSpec.feature 'Booking manager views their locations' do
     end
   end
 
-  def given_the_user_is_identified_as_a_booking_manager
-    @user = create(:booking_manager)
-    GDS::SSO.test_user = @user
-
-    yield
-  ensure
-    GDS::SSO.test_user = nil
-  end
-
   def and_they_have_assigned_locations
     @location = create(:location)
 

--- a/spec/features/guider_views_bookings_spec.rb
+++ b/spec/features/guider_views_bookings_spec.rb
@@ -14,15 +14,6 @@ RSpec.feature 'Guider views bookings' do
     end
   end
 
-  def given_the_user_is_identified_as_a_guider
-    @user = create(:guider)
-    GDS::SSO.test_user = @user
-
-    yield
-  ensure
-    GDS::SSO.test_user = nil
-  end
-
   def when_they_visit_the_root
     visit root_path
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,4 +18,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include FactoryGirl::Syntax::Methods
+  config.include UserHelpers
 end

--- a/spec/requests/location_rooms_api_spec.rb
+++ b/spec/requests/location_rooms_api_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /locations/:location_id/rooms.json' do
+  scenario 'Retrieving rooms as JSON' do
+    given_the_user_is_identified_as_a_booking_manager do
+      and_they_have_an_assigned_location
+      when_they_request_the_rooms_for_their_location
+      then_the_service_responds_ok
+      and_the_rooms_are_serialized_as_json
+    end
+  end
+
+  def and_they_have_an_assigned_location
+    @location = create(:location)
+
+    @user.locations << @location
+  end
+
+  def when_they_request_the_rooms_for_their_location
+    get location_rooms_path(@location), as: :json
+  end
+
+  def then_the_service_responds_ok
+    expect(response).to be_ok
+  end
+
+  def and_the_rooms_are_serialized_as_json
+    JSON.parse(response.body).tap do |json|
+      expect(json.first.keys).to match_array(%w(id title))
+    end
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -1,0 +1,19 @@
+module UserHelpers
+  def given_the_user_is_identified_as_a_booking_manager
+    @user = create(:booking_manager)
+    GDS::SSO.test_user = @user
+
+    yield
+  ensure
+    GDS::SSO.test_user = nil
+  end
+
+  def given_the_user_is_identified_as_a_guider
+    @user = create(:guider)
+    GDS::SSO.test_user = @user
+
+    yield
+  ensure
+    GDS::SSO.test_user = nil
+  end
+end


### PR DESCRIPTION
This adds a location-specific API for rooms or 'resources' in fullcalendar parlance.
    
 Issuing: `GET /locations/:location_id/rooms.json` will result in a
 serialized JSON response containing rooms ordered by name with the keys
 `id` and `title` matching fullcalendar's expectations.

Example response:

```javascript
[
  {
    "id": 1,
    "title": "Room no.2"
  },
  {
    "id": 2,
    "title": "Room no.3"
  },
  {
    "id": 3,
    "title": "Room no.4"
  }
]
```