### PR TITLE
Ensure managers can only delete their DC slots

### DIFF
--- a/app/assets/javascripts/modules/availability-calendar.es6
+++ b/app/assets/javascripts/modules/availability-calendar.es6
@@ -86,6 +86,9 @@
             $(this.$el).fullCalendar('refetchEvents')
 
             this.showSuccess()
+          },
+          error: () => {
+            alert('You cannot delete slots belonging to other delivery centres')
           }
         })
       }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,12 @@ class ApplicationController < ActionController::Base
 
   before_action :require_signin_permission!
 
+  rescue_from ActiveRecord::RecordNotFound do
+    respond_to do |format|
+      format.json { head :not_found }
+    end
+  end
+
   protected
 
   def authorise_booking_manager!

--- a/app/controllers/slots_controller.rb
+++ b/app/controllers/slots_controller.rb
@@ -10,9 +10,8 @@ class SlotsController < ApplicationController
   end
 
   def create
-    Slot.create!(
-      room: location.rooms.find(params[:room_id]),
-      delivery_centre: current_user.delivery_centre,
+    current_user.slots.create!(
+      room: room,
       start_at: params[:start_at]
     )
 
@@ -26,6 +25,10 @@ class SlotsController < ApplicationController
   end
 
   private
+
+  def room
+    location.rooms.find(params[:room_id])
+  end
 
   def location
     @location ||= current_user.location

--- a/app/controllers/slots_controller.rb
+++ b/app/controllers/slots_controller.rb
@@ -19,7 +19,7 @@ class SlotsController < ApplicationController
   end
 
   def destroy
-    location.slots.find(params[:id]).destroy
+    current_user.slots.destroy(params[:id])
 
     head :no_content
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   belongs_to :delivery_centre, optional: true
 
-  delegate :location, to: :delivery_centre
+  delegate :location, :slots, to: :delivery_centre
 
   def booking_manager?
     has_permission?(BOOKING_MANAGER)

--- a/spec/features/booking_manager_manages_availability_spec.rb
+++ b/spec/features/booking_manager_manages_availability_spec.rb
@@ -5,11 +5,14 @@ RSpec.feature 'Booking manager manages availability' do
     travel_to '2017-08-11 13:00' do
       given_the_user_is_identified_as_a_booking_manager do
         and_they_have_an_assigned_location_with_availability
+        and_slots_from_another_delivery_centre
         when_they_view_availability_for_their_location
         then_they_see_the_associated_rooms
         and_they_see_the_slots_for_their_location
         when_they_click_an_existing_slot
         then_the_slot_is_removed
+        when_they_click_a_slot_from_another_delivery_centre
+        then_the_slot_is_not_removed
       end
     end
   end
@@ -36,6 +39,17 @@ RSpec.feature 'Booking manager manages availability' do
     )
   end
 
+  def and_slots_from_another_delivery_centre
+    @other_delivery_centre = create(:delivery_centre, location: @user.location)
+
+    create(
+      :slot,
+      delivery_centre: @other_delivery_centre,
+      room: @user.location.rooms.first,
+      start_at: 2.hours.from_now
+    )
+  end
+
   def when_they_view_availability_for_their_location
     @page = Pages::Availability.new
     @page.load
@@ -48,7 +62,7 @@ RSpec.feature 'Booking manager manages availability' do
   def and_they_see_the_slots_for_their_location
     @page.wait_until_slots_visible
 
-    expect(@page).to have_slots(count: 1)
+    expect(@page).to have_slots(count: 2)
   end
 
   def when_they_click_an_existing_slot
@@ -70,6 +84,17 @@ RSpec.feature 'Booking manager manages availability' do
 
   def then_the_slot_is_created
     @page.wait_until_slots_visible
+    expect(@page).to have_slots(count: 1)
+  end
+
+  def when_they_click_a_slot_from_another_delivery_centre
+    @page.dismiss_confirmations
+
+    @page.wait_until_slots_visible
+    @page.slots.first.click
+  end
+
+  def then_the_slot_is_not_removed
     expect(@page).to have_slots(count: 1)
   end
 end


### PR DESCRIPTION
Previously we would allow any manager to delete any slot in a given
location, regardless of which delivery centre it (or they) belonged to.