### PR TITLE
Wait for calendar to finish binding events

### DIFF
--- a/app/assets/javascripts/modules/availability-calendar.es6
+++ b/app/assets/javascripts/modules/availability-calendar.es6
@@ -53,10 +53,20 @@
         eventRender: (event, element) => {
           $(element).attr('id', event.id).addClass('t-slot js-slot')
         },
+        eventAfterAllRender: () => {
+          // mark the calendar as reloaded
+          let $rendered = $("<div class='t-calendar-rendered' style='display:hidden;'></div>")
+          $('body').append($rendered);
+        },
         resourceRender: (resource, labelTds) => {
           labelTds.addClass('t-room')
         },
         loading: (isLoading) => {
+          if (isLoading) {
+            // mark the calendar as reloading
+            $('.t-calendar-rendered').remove()
+          }
+
           this.insertLoadingView();
 
           if (!isLoading && this.$loadingSpinner) {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,12 @@
 
 <% content_for :body_end do %>
   <%= javascript_include_tag 'application' %>
+
+  <% if Rails.env.test? %>
+    <script>
+      $.fx.off = true;
+    </script>
+  <% end %>
 <% end %>
 
 <%= render template: 'layouts/govuk_admin_template' %>

--- a/spec/features/booking_manager_manages_availability_spec.rb
+++ b/spec/features/booking_manager_manages_availability_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Booking manager manages availability' do
   end
 
   def and_they_see_the_slots_for_their_location
-    @page.wait_until_slots_visible
+    @page.wait_for_calendar_events
 
     expect(@page).to have_slots(count: 2)
   end
@@ -72,6 +72,8 @@ RSpec.feature 'Booking manager manages availability' do
   end
 
   def then_the_slot_is_removed
+    @page.wait_until_success_visible
+
     expect(@page).to have_success
   end
 
@@ -83,14 +85,14 @@ RSpec.feature 'Booking manager manages availability' do
   end
 
   def then_the_slot_is_created
-    @page.wait_until_slots_visible
+    @page.wait_for_calendar_events
     expect(@page).to have_slots(count: 1)
   end
 
   def when_they_click_a_slot_from_another_delivery_centre
     @page.dismiss_confirmations
 
-    @page.wait_until_slots_visible
+    @page.wait_for_calendar_events
     @page.slots.first.click
   end
 

--- a/spec/support/pages/availability.rb
+++ b/spec/support/pages/availability.rb
@@ -8,6 +8,10 @@ module Pages
     element :success, '.t-success'
     element :day, '.fc-agendaDay-button'
 
+    def wait_for_calendar_events
+      find('.t-calendar-rendered', visible: false)
+    end
+
     def dismiss_confirmations
       page.evaluate_script <<-JS
         window.confirm = function() {


### PR DESCRIPTION
We can't rely on the super-flakey `wait_until_x_visible` stuff (not due
to siteprism, firmly due to fullcalendar) so I've lifted this from the
other projects. It's hacky but reliably waits for the calendar to
finish its business.