### PR TITLE
Introduce external locations API

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class LocationsController < ActionController::Base
+      def index
+        render json: Location.order(:name).all
+      end
+    end
+  end
+end

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -1,0 +1,12 @@
+class LocationSerializer < ActiveModel::Serializer
+  attributes %i(
+    id
+    name
+    address_line_one
+    address_line_two
+    address_line_three
+    town
+    county
+    postcode
+  )
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
   root 'slots#index'
 
+  namespace :api, defaults: { format: :json } do
+    namespace :v1 do
+      resources :locations, only: :index
+    end
+  end
+
   resources :rooms, only: :index
   resources :slots, only: %i(index create destroy)
 end

--- a/spec/requests/locations_api_spec.rb
+++ b/spec/requests/locations_api_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /api/v1/locations.json' do
+  scenario 'Requesting the locations' do
+    given_locations_exist
+    when_a_client_requests_locations
+    then_the_service_responds_ok
+    and_the_locations_are_serialized_as_json
+  end
+
+  def given_locations_exist
+    @hq    = create(:location, name: 'Tesco Headquarters')
+    @other = create(:location, name: 'Tesco Inverness')
+  end
+
+  def when_a_client_requests_locations
+    get api_v1_locations_path, as: :json
+  end
+
+  def then_the_service_responds_ok
+    expect(response).to be_ok
+  end
+
+  def and_the_locations_are_serialized_as_json
+    JSON.parse(response.body).tap do |json|
+      expect(json.length).to eq(2)
+
+      expect(json.first['name']).to eq(@hq.name)
+
+      expect(json.first.keys).to match_array(
+        %w(id name address_line_one address_line_two address_line_three town county postcode)
+      )
+    end
+  end
+end


### PR DESCRIPTION
Provides a serialized list of locations ordered by name via `GET
/api/v1/locations`.