### PR TITLE
Allow booking managers to leave messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-bootstrap-daterangepicker'
   gem 'rails-assets-fullcalendar', '3.4.0'
   gem 'rails-assets-fullcalendar-scheduler', '1.6.2'
+  gem 'rails-assets-pusher'
 end
 
 source 'https://rubygems.org' do
@@ -19,6 +20,7 @@ source 'https://rubygems.org' do
   gem 'pg', '~> 0.18'
   gem 'plek'
   gem 'puma'
+  gem 'pusher'
   gem 'rails', '~> 5.1.2'
   gem 'sassc-rails'
   gem 'sidekiq'
@@ -31,6 +33,7 @@ source 'https://rubygems.org' do
     gem 'factory_girl_rails'
     gem 'phantomjs'
     gem 'pry-byebug'
+    gem 'pusher-fake'
     gem 'rspec-rails'
     gem 'site_prism'
   end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,11 +77,25 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    cookiejar (0.3.3)
+    daemons (1.2.4)
     database_rewinder (0.8.2)
     diff-lcs (1.3)
+    em-http-request (1.1.5)
+      addressable (>= 2.3.4)
+      cookiejar (!= 0.3.1)
+      em-socksify (>= 0.3)
+      eventmachine (>= 1.0.3)
+      http_parser.rb (>= 0.6.0)
+    em-socksify (0.3.1)
+      eventmachine (>= 1.0.0.beta.4)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
     email_validator (1.6.0)
       activemodel
     erubi (1.6.1)
+    eventmachine (1.2.5)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -106,6 +120,8 @@ GEM
       jquery-rails (~> 4.3.1)
       rails (>= 3.2.0)
     hashie (3.5.6)
+    http_parser.rb (0.6.0)
+    httpclient (2.8.3)
     i18n (0.8.6)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -187,6 +203,16 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.0)
     puma (3.10.0)
+    pusher (1.3.1)
+      httpclient (~> 2.7)
+      multi_json (~> 1.0)
+      pusher-signature (~> 0.1.8)
+    pusher-fake (1.8.0)
+      em-http-request (~> 1.1)
+      em-websocket (~> 0.5)
+      multi_json (~> 1.6)
+      thin (~> 1.5)
+    pusher-signature (0.1.8)
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
@@ -216,6 +242,7 @@ GEM
       rails-assets-moment (>= 2.9.0, < 3)
     rails-assets-jquery (3.2.1)
     rails-assets-moment (2.18.1)
+    rails-assets-pusher (4.1.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -306,6 +333,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -347,10 +378,13 @@ DEPENDENCIES
   poltergeist!
   pry-byebug!
   puma!
+  pusher!
+  pusher-fake!
   rails (~> 5.1.2)!
   rails-assets-bootstrap-daterangepicker!
   rails-assets-fullcalendar (= 3.4.0)!
   rails-assets-fullcalendar-scheduler (= 1.6.2)!
+  rails-assets-pusher!
   rails_12factor!
   rspec-rails!
   rubocop (= 0.49.1)!

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,4 +3,6 @@
 //= require fullcalendar
 //= require fullcalendar-scheduler
 //= require bootstrap-daterangepicker
+//= require pusher
+
 //= require_tree .

--- a/app/assets/javascripts/modules/activity-feed.es6
+++ b/app/assets/javascripts/modules/activity-feed.es6
@@ -1,0 +1,57 @@
+/* global Pusher */
+'use strict';
+{
+  class ActivityFeed {
+    start(el) {
+      this.$el = el;
+      this.$showAllButton = $('.js-activity-show-all');
+      this.hideableClass = 'activity--hideable';
+      this.hideClass = 'activity--hide';
+      this.config = this.$el.data('config');
+
+      this.setupPusher();
+      this.bindEvents();
+    }
+
+    setupPusher() {
+      const channel = Pusher.instance.subscribe('pension_wise_tesco');
+
+      channel.bind(this.config.event, this.handlePushEvent.bind(this));
+
+      $(window).on('beforeunload', () => {
+        channel.unbind(this.config.event, this.handlePushEvent.bind(this));
+      });
+    }
+
+    handlePushEvent(payload) {
+      let $element = $(payload.body);
+
+      if (this.isUnique($element)) {
+        $element
+          .hide()
+          .prependTo(this.$el)
+          .fadeIn();
+      }
+    }
+
+    bindEvents() {
+      this.$showAllButton.on('click', this.handleShowAllClick.bind(this));
+    }
+
+    handleShowAllClick(event) {
+      const $button = $(event.currentTarget),
+        $target = $(`#${$button.attr('aria-controls')}`);
+
+      $button.attr('aria-expanded', $button.attr('aria-expanded') === 'false' ? 'true' : 'false');
+      $target.find(`.${this.hideableClass}`).toggleClass(this.hideClass);
+    }
+
+    isUnique($element) {
+      const activityID = $element.attr('data-activity-id');
+
+      return !$(`.activity[data-activity-id='${activityID}']`).length;
+    }
+  }
+
+  window.GOVUKAdmin.Modules.ActivityFeed = ActivityFeed;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,4 @@
 
 @import 'lib/*';
 @import 'components/*';
+@import "helper/*";

--- a/app/assets/stylesheets/components/_activity-feed.scss
+++ b/app/assets/stylesheets/components/_activity-feed.scss
@@ -1,0 +1,11 @@
+.activity-feed__input {
+  @media (max-width: $screen-xs-max) {
+    display: block;
+  }
+}
+
+.activity-feed__button {
+  @media (max-width: $screen-xs-max) {
+    border-radius: 0;
+  }
+}

--- a/app/assets/stylesheets/components/_activity.scss
+++ b/app/assets/stylesheets/components/_activity.scss
@@ -1,0 +1,100 @@
+.activity--hide {
+  .js & {
+    display: none;
+  }
+}
+
+.activity__link {
+  &:link,
+  &:visited {
+    text-decoration: none;
+    color: $color-black;
+  }
+
+  &:hover,
+  &:focus {
+    &::after {
+      background: transparentize($color-black, .9);
+    }
+
+    .dropdown-menu & {
+      background: transparent;
+    }
+  }
+
+  &::after {
+    content: "";
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    position: absolute;
+  }
+}
+
+.activity__link--more {
+  display: block;
+  padding-right: 20px;
+
+  &::before {
+    background-image: url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%3E%3Cpath%20d%3D%22M4%201h6l10%2011-10%2011H4l10-11z%22%20fill%3D%22%238a8a8a%22%2F%3E%3C%2Fsvg%3E);
+    background-repeat: no-repeat;
+    background-position: 5px center;
+    content: "";
+    height: 100%;
+    position: absolute;
+    right: 5px;
+    top: 0;
+    width: 30px;
+  }
+}
+
+.activity__date {
+  color: $color-dove-gray;
+  display: block;
+  font-size: 80%;
+}
+
+.activity__date--dropdown {
+  margin-left: 0;
+}
+
+.activity__resolve {
+  position: absolute;
+  z-index: 2;
+  right: 16px;
+  top: 14px;
+}
+
+.activity {
+  .loading-spinner {
+    margin: 10px 0;
+  }
+
+  .glyphicon {
+    position: absolute;
+    top: .9em;
+    left: 10px;
+  }
+}
+
+.activity--none {
+  padding: 10px;
+}
+
+.activity__inner {
+  padding-left: 16px;
+}
+
+.activity--view-all {
+  border-bottom: 0;
+  padding: .5em 0;
+
+  .glyphicon {
+    position: static;
+  }
+}
+
+.activity__form {
+  margin: 0;
+}

--- a/app/assets/stylesheets/components/_calendars.scss
+++ b/app/assets/stylesheets/components/_calendars.scss
@@ -1,7 +1,3 @@
-$color-white: #fff;
-$color-black: #000;
-$color-boston-blue: #3a87ad;
-
 $calendar-loading-view-background: transparentize($color-white, .2);
 
 .fc {

--- a/app/assets/stylesheets/helper/_show-hide.scss
+++ b/app/assets/stylesheets/helper/_show-hide.scss
@@ -1,0 +1,7 @@
+.show-with-js {
+  display: none;
+
+  .js & {
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/lib/_colours.scss
+++ b/app/assets/stylesheets/lib/_colours.scss
@@ -1,0 +1,4 @@
+$color-white: #fff;
+$color-black: #000;
+$color-boston-blue: #3a87ad;
+$color-dove-gray: #707070;

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,29 @@
+class ActivitiesController < ApplicationController
+  before_action :authorise_booking_manager!
+
+  def create
+    @activity = appointment.activities.create(activity_params)
+    send_push_notifications(@activity)
+
+    respond_to do |format|
+      format.js { render @activity }
+    end
+  end
+
+  private
+
+  def send_push_notifications(activity)
+    PusherNotificationJob.perform_later(activity)
+  end
+
+  def appointment
+    @appointment ||= current_user.appointments.find(params[:appointment_id])
+  end
+
+  def activity_params
+    params
+      .require(:activity)
+      .permit(:message)
+      .merge(user: current_user)
+  end
+end

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -56,7 +56,10 @@ class AppointmentsController < ApplicationController
 
   def load_appointment
     @appointment = AppointmentDecorator.new(
-      current_user.appointments.find(params[:id])
+      current_user
+        .appointments
+        .includes(activities: :user)
+        .find(params[:id])
     )
   end
 end

--- a/app/jobs/pusher_notification_job.rb
+++ b/app/jobs/pusher_notification_job.rb
@@ -1,0 +1,17 @@
+class PusherNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(activity)
+    Pusher.trigger(
+      Pusher.app_id,
+      "appointment_activity_#{activity.appointment_id}",
+      body: render_activity(activity)
+    )
+  end
+
+  private
+
+  def render_activity(activity)
+    ApplicationController.render(partial: activity, locals: { hide: false })
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,6 @@
+class Activity < ApplicationRecord
+  belongs_to :user
+  belongs_to :appointment
+
+  default_scope { order(created_at: :desc) }
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,6 +1,7 @@
 class Appointment < ApplicationRecord
   belongs_to :slot
   has_one :delivery_centre, through: :slot
+  has_many :activities
 
   before_validation :calculate_type_of_appointment
 

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -1,0 +1,11 @@
+<li
+  class="activity list-group-item t-activity <%= 't-hidden-activity activity--hideable activity--hide' if hide %>"
+  data-activity-id="<%= activity.id %>">
+  <div class="activity__inner">
+    <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
+    <strong><%= activity.user.name %></strong> said <em><%= activity.message %></em>
+    <span class="activity__date">
+      <%= activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(activity.created_at.in_time_zone('London'))%> ago)
+    </span>
+  </div>
+</li>

--- a/app/views/activities/_activity.js.erb
+++ b/app/views/activities/_activity.js.erb
@@ -1,0 +1,1 @@
+$('.js-message').val('');

--- a/app/views/appointments/_activities.html.erb
+++ b/app/views/appointments/_activities.html.erb
@@ -1,0 +1,36 @@
+<div class="row t-activity-feed">
+  <div class="col-md-12 border-bottom">
+    <h2>Recent activity</h2>
+
+    <div class="activity-feed">
+      <div class="well js-message-form">
+        <%= form_for Activity.new(appointment: appointment.object, user: current_user), url: appointment_activities_path(appointment), remote: true do |f| %>
+          <div class="input-group activity-feed__input">
+            <label for="message_activity_message"><span class="sr-only">Activity message</span></label>
+            <%= f.text_field :message, placeholder: 'Add an action to keep others in the loop', class: 'form-control js-message t-message' %>
+            <span class="input-group-btn">
+              <%= f.button class: 'btn btn-primary btn-block t-submit-message activity-feed__button', data: { disable_with: 'Adding message...' } do %>
+                <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                Add message
+              <% end %>
+            </span>
+          </div>
+        <% end %>
+      </div>
+
+      <ol class="list-group" aria-live="polite" data-module="activity-feed" id="activity-list" data-config='{"event": "appointment_activity_<%= appointment.id %>"}' aria-label="Activities">
+        <%= render(appointment.activities[0..2], hide: false) if appointment.activities.present? %>
+        <% if appointment.activities.count > 3 %>
+          <%= render(appointment.activities - Array(appointment.activities[0..2]), hide: true) %>
+        <% end %>
+      </ol>
+
+      <% if appointment.activities.count > 3 %>
+        <button class="show-with-js js-activity-show-all btn btn-default t-further-activities" aria-expanded="false" aria-controls="activity-list">
+          <span class="glyphicon glyphicon-th-list" aria-hidden="true"></span>
+          All activity
+        </button>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -12,6 +12,9 @@
   </h1>
 </div>
 
+<%= render partial: 'activities', locals: { appointment: @appointment } %>
+<hr>
+
 <%= form_for @appointment.object do |f| %>
   <div class="row">
     <div class="col-md-12 l-appointment-details">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,17 @@
 <% content_for :body_end do %>
   <%= javascript_include_tag 'application' %>
 
+  <script>
+  <% if defined?(PusherFake) %>
+      Pusher.instance = <%= raw PusherFake.javascript %>;
+  <% else %>
+      Pusher.instance = new Pusher('<%= ENV['PUSHER_KEY'] %>', {
+        cluster: 'eu',
+        encrypted: true
+      });
+  <% end %>
+  </script>
+
   <% if Rails.env.test? %>
     <script>
       $.fx.off = true;

--- a/config/initializers/pusher.rb
+++ b/config/initializers/pusher.rb
@@ -1,0 +1,5 @@
+Pusher.app_id = ENV.fetch('PUSHER_APP_ID') { 'pension_wise_tesco' }
+Pusher.key    = ENV.fetch('PUSHER_KEY')    { 'pusher_key' }
+Pusher.secret = ENV.fetch('PUSHER_SECRET') { 'pusher_secret' }
+
+require 'pusher-fake/support/base' if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   resources :appointments, only: %i[index show edit update] do
     resource :reschedule, only: %i[edit update]
+    resources :activities, only: :create
   end
   resources :rooms, only: :index
   resources :slots, only: %i[index create destroy]

--- a/db/migrate/20170922112631_create_activities.rb
+++ b/db/migrate/20170922112631_create_activities.rb
@@ -1,0 +1,10 @@
+class CreateActivities < ActiveRecord::Migration[5.1]
+  def change
+    create_table :activities do |t|
+      t.belongs_to :user, foreign_key: true
+      t.belongs_to :appointment, index: true, foreign_key: true
+      t.string :message, null: false, default: ''
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922085419) do
+ActiveRecord::Schema.define(version: 20170922112631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "activities", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "appointment_id"
+    t.string "message", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["appointment_id"], name: "index_activities_on_appointment_id"
+    t.index ["user_id"], name: "index_activities_on_user_id"
+  end
 
   create_table "appointments", force: :cascade do |t|
     t.bigint "slot_id", null: false
@@ -87,6 +97,8 @@ ActiveRecord::Schema.define(version: 20170922085419) do
     t.index ["delivery_centre_id"], name: "index_users_on_delivery_centre_id"
   end
 
+  add_foreign_key "activities", "appointments"
+  add_foreign_key "activities", "users"
   add_foreign_key "appointments", "slots"
   add_foreign_key "delivery_centres", "locations"
   add_foreign_key "slots", "delivery_centres"

--- a/spec/features/booking_manager_creates_activities_spec.rb
+++ b/spec/features/booking_manager_creates_activities_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking manager creates activities' do
+  scenario 'Creating a message activity', js: true do
+    perform_enqueued_jobs do
+      given_the_user_is_identified_as_a_booking_manager do
+        and_there_is_an_appointment
+        when_they_view_the_appointment
+        and_they_leave_a_message
+        then_they_see_their_new_message
+        and_the_message_field_is_cleared
+      end
+    end
+  end
+
+  def and_there_is_an_appointment
+    @appointment = appointment_for_user(@user)
+  end
+
+  def when_they_view_the_appointment
+    @page = Pages::Appointment.new
+    @page.load(id: @appointment.id)
+  end
+
+  def and_they_leave_a_message
+    @page.message.set('Customer called to cancel.')
+    @page.submit_message.click
+  end
+
+  def then_they_see_their_new_message
+    @page.wait_until_activities_visible
+
+    expect(@page).to have_activities(count: 1)
+  end
+
+  def and_the_message_field_is_cleared
+    expect(@page.message).to have_text('')
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 
 require 'spec_helper'
 require 'rspec/rails'
+require 'pusher-fake/support/rspec'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }

--- a/spec/support/pages/appointment.rb
+++ b/spec/support/pages/appointment.rb
@@ -2,6 +2,10 @@ module Pages
   class Appointment < SitePrism::Page
     set_url '/appointments/{id}/edit'
 
+    element :message, '.t-message'
+    element :submit_message, '.t-submit-message'
+    elements :activities, '.t-activity'
+
     element :first_name, '.t-first-name'
     element :last_name, '.t-last-name'
     element :email, '.t-email'


### PR DESCRIPTION
Adds an activity feed to the appointment edit screen and lets booking
managers leave messages against particular appointments.

Makes use of pusher for realtime feed updates.