### PR TITLE
Restrict external locations to `active` only

### DIFF
--- a/app/controllers/api/v1/locations_controller.rb
+++ b/app/controllers/api/v1/locations_controller.rb
@@ -2,7 +2,7 @@ module Api
   module V1
     class LocationsController < ActionController::Base
       def index
-        render json: Location.order(:name).all
+        render json: Location.active.order(:name).all
       end
 
       def show
@@ -12,7 +12,7 @@ module Api
       private
 
       def location
-        @location ||= Location.find(params[:id])
+        @location ||= Location.active.find(params[:id])
       end
     end
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -11,6 +11,8 @@ class Location < ApplicationRecord
   validates :county, presence: true
   validates :postcode, presence: true
 
+  scope :active, -> { where(active: true) }
+
   def available_slot(start_at)
     slots.available.find_by(start_at: start_at)
   end


### PR DESCRIPTION
Ensures administrators can work on locations in the background until
they're ready to launch.