### PR TITLE
Allow booking managers to choose a DC

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,11 @@
+class HomeController < ApplicationController
+  before_action :authorise_booking_manager!
+
+  def index
+    if current_user.assigned?
+      redirect_to appointments_path, status: :moved_permanently
+    else
+      redirect_to edit_user_path
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,28 @@
+class UsersController < ApplicationController
+  before_action :authorise_booking_manager!
+  before_action :load_locations
+
+  def edit
+  end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to appointments_path, success: 'Your delivery centre has been assigned.'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:delivery_centre_id)
+  end
+
+  def load_locations
+    @locations = Location
+                 .joins(:delivery_centres)
+                 .all
+                 .order('locations.name, delivery_centres.name')
+  end
+end

--- a/app/helpers/appointment_helper.rb
+++ b/app/helpers/appointment_helper.rb
@@ -1,4 +1,13 @@
 module AppointmentHelper
+  def grouped_delivery_centres(locations)
+    locations.map do |location|
+      [
+        location.name,
+        location.delivery_centres.pluck(:name, :id)
+      ]
+    end
+  end
+
   def grouped_slots(slots)
     [].tap do |result|
       grouped = slots.group_by { |slot| slot.start_at.to_date.to_s(:govuk_date) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,10 @@ class User < ApplicationRecord
       .order(:created_at)
   end
 
+  def assigned?
+    delivery_centre_id?
+  end
+
   def mine?(slot)
     slot.delivery_centre_id == delivery_centre_id
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,37 @@
+<% content_for(:page_title, "Assign #{current_user.name}") %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Tesco appointment planner</a></li>
+    <li class="active">Choose your delivery centre</li>
+  </ol>
+
+  <h1>Choose your delivery centre</h1>
+</div>
+
+<%= form_for current_user do |f| %>
+  <div class="row">
+    <div class="col-md-5">
+      <% if current_user.errors.any? %>
+        <div class="alert alert-danger t-errors" role="alert">
+          <h3 class="alert__heading h4">There's a problem</h3>
+          <ul>
+            <% current_user.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="form-group">
+        <%= f.label :delivery_centre_id, 'Delivery centre' %>
+        <%= f.select :delivery_centre_id,
+              grouped_options_for_select(grouped_delivery_centres(@locations)),
+              {},
+              { class: 'form-control t-delivery-centres' }
+        %>
+      </div>
+
+      <%= f.button 'Choose your delivery centre', class: 'btn btn-primary t-submit' %>
+    </div>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  root 'slots#index'
+  root 'home#index'
+
+  resource :user, only: %i[edit update]
 
   namespace :api, defaults: { format: :json } do
     namespace :v1 do

--- a/spec/features/booking_manager_assigns_their_delivery_centre_spec.rb
+++ b/spec/features/booking_manager_assigns_their_delivery_centre_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking manager assigns their delivery centre' do
+  scenario 'They are already assigned' do
+    given_the_user_is_identified_as_a_booking_manager do
+      when_they_visit_the_application
+      then_they_are_redirected_to_their_appointments
+    end
+  end
+
+  scenario 'They are not yet assigned' do
+    given_the_user_is_identified_as_a_booking_manager(delivery_centre: nil) do
+      and_a_delivery_centre_exists
+      when_they_visit_the_application
+      and_they_choose_a_delivery_centre
+      then_they_are_redirected_to_their_appointments
+    end
+  end
+
+  def and_a_delivery_centre_exists
+    @delivery_centre = create(:delivery_centre)
+  end
+
+  def when_they_visit_the_application
+    visit root_path
+  end
+
+  def and_they_choose_a_delivery_centre
+    page.find('.t-delivery-centres').select(@delivery_centre.name)
+    page.find('.t-submit').click
+  end
+
+  def then_they_are_redirected_to_their_appointments
+    expect(page.current_path).to eq(appointments_path)
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -17,8 +17,8 @@ module UserHelpers
     GDS::SSO.test_user = nil
   end
 
-  def given_the_user_is_identified_as_a_booking_manager
-    @user = create(:booking_manager)
+  def given_the_user_is_identified_as_a_booking_manager(opts = {})
+    @user = create(:booking_manager, opts)
     GDS::SSO.test_user = @user
 
     yield


### PR DESCRIPTION
Booking managers can self-assign a delivery centre they wish to serve,
upon first access of the planner.