### PR TITLE
Return slot to pool after cancellation

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -16,7 +16,7 @@ class AppointmentsController < ApplicationController
 
   def update
     if @appointment.update(appointment_params)
-      send_notifications(@appointment)
+      handle_cancellation(@appointment)
       redirect_to appointments_path, success: 'The appointment was updated.'
     else
       render :edit
@@ -32,10 +32,10 @@ class AppointmentsController < ApplicationController
     appointments.includes(:slot).where(slots: { start_at: starts..ends })
   end
 
-  def send_notifications(appointment)
-    return unless appointment.status_previously_changed? && appointment.cancelled?
-
-    AppointmentMailer.cancellation(appointment.object).deliver_later
+  def handle_cancellation(appointment)
+    appointment.handle_cancellation! do
+      AppointmentMailer.cancellation(appointment.object).deliver_later
+    end
   end
 
   def appointment_params # rubocop:disable Metrics/MethodLength

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -25,6 +25,13 @@ class Appointment < ApplicationRecord
   validates :slot, presence: true, uniqueness: true
   validates :type_of_appointment, presence: true
 
+  def handle_cancellation!
+    return unless status_previously_changed? && cancelled?
+
+    slot.free!
+    yield self
+  end
+
   def booking_managers
     delivery_centre.users.active
   end

--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -13,6 +13,15 @@ class Slot < ApplicationRecord
     left_outer_joins(:appointment).where(appointments: { id: nil })
   }
 
+  def free!
+    Slot.create!(
+      start_at: start_at,
+      end_at: end_at,
+      room: room,
+      delivery_centre: delivery_centre
+    )
+  end
+
   private
 
   def infer_end_at!

--- a/spec/features/booking_manager_manages_an_appointment_spec.rb
+++ b/spec/features/booking_manager_manages_an_appointment_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature 'Booking manager manages an appointment' do
       and_they_have_an_associated_appointment
       when_the_appointment_is_cancelled
       then_the_customer_is_notified
+      and_the_original_slot_is_still_available
     end
   end
 
@@ -87,5 +88,11 @@ RSpec.feature 'Booking manager manages an appointment' do
 
   def then_the_customer_is_notified
     expect(ActionMailer::Base.deliveries.first.to).to match_array(@appointment.email)
+  end
+
+  def and_the_original_slot_is_still_available
+    expect(
+      Slot.available.find_by(start_at: @appointment.slot.start_at)
+    ).to be
   end
 end


### PR DESCRIPTION
Duplicates the original slot after a cancellation, thus returning the
slot to the pool of available slots.