### PR TITLE
Add identifying mailgun variables to emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,4 +2,14 @@ class ApplicationMailer < ActionMailer::Base
   default from: 'Tesco Pension Wise Appointments <appointments@pensionwise.gov.uk>'
 
   layout 'mailer'
+
+  protected
+
+  def mailgun_headers(message_type, appointment)
+    headers['X-Mailgun-Variables'] = {
+      message_type: message_type,
+      appointment_id: appointment.to_param,
+      environment: Rails.env
+    }.to_json
+  end
 end

--- a/app/mailers/appointment_mailer.rb
+++ b/app/mailers/appointment_mailer.rb
@@ -4,18 +4,21 @@ class AppointmentMailer < ApplicationMailer
   def reminder(appointment)
     @appointment = appointment
 
+    mailgun_headers(:reminder, appointment)
     mail to: appointment.email, reply_to: appointment.delivery_centre.reply_to
   end
 
   def cancellation(appointment)
     @appointment = appointment
 
+    mailgun_headers(:cancellation, appointment)
     mail to: appointment.email, reply_to: appointment.delivery_centre.reply_to
   end
 
   def customer(appointment)
     @appointment = appointment
 
+    mailgun_headers(:confirmation, appointment)
     mail to: appointment.email, reply_to: appointment.delivery_centre.reply_to
   end
 

--- a/spec/mailers/appointment_mailer_spec.rb
+++ b/spec/mailers/appointment_mailer_spec.rb
@@ -2,12 +2,17 @@ require 'rails_helper'
 
 RSpec.describe AppointmentMailer do
   let(:appointment) { create(:appointment, :with_slot) }
+  let(:mailgun_headers) { JSON.parse(subject['X-Mailgun-Variables'].value) }
 
   describe '#reminder' do
     subject do
       travel_to '2017-09-16 13:00 UTC' do
         described_class.reminder(appointment)
       end
+    end
+
+    it 'is identified for mailgun' do
+      expect(mailgun_headers).to include('message_type' => 'reminder')
     end
 
     it 'contains the necessary detail' do
@@ -33,6 +38,10 @@ RSpec.describe AppointmentMailer do
       end
     end
 
+    it 'is identified for mailgun' do
+      expect(mailgun_headers).to include('message_type' => 'confirmation')
+    end
+
     it 'contains the necessary detail' do
       expect(subject.to).to match_array('rick@example.com')
 
@@ -51,6 +60,10 @@ RSpec.describe AppointmentMailer do
 
   describe '#cancellation' do
     subject { described_class.cancellation(appointment) }
+
+    it 'is identified for mailgun' do
+      expect(mailgun_headers).to include('message_type' => 'cancellation')
+    end
 
     it 'contains the necessary detail' do
       expect(subject.to).to match_array('rick@example.com')


### PR DESCRIPTION
This is to identify drops when inbound webhooks are triggered.