### PR TITLE
Handle inbound hooks from MailGun

### DIFF
--- a/app/controllers/mailgun/drops_controller.rb
+++ b/app/controllers/mailgun/drops_controller.rb
@@ -1,0 +1,25 @@
+module Mailgun
+  class DropsController < ActionController::Base
+    def create
+      @activity = DropForm.new(drop_params).create_activity
+      PusherNotificationJob.perform_later(@activity)
+
+      head :ok
+    end
+
+    private
+
+    def drop_params
+      params.permit(
+        :event,
+        :description,
+        :appointment_id,
+        :message_type,
+        :environment,
+        :timestamp,
+        :token,
+        :signature
+      )
+    end
+  end
+end

--- a/app/lib/drop_form.rb
+++ b/app/lib/drop_form.rb
@@ -1,0 +1,56 @@
+require 'openssl'
+
+TokenVerificationFailure = Class.new(StandardError)
+
+class DropForm
+  include ActiveModel::Model
+
+  attr_accessor :event
+  attr_accessor :description
+  attr_accessor :appointment_id
+  attr_accessor :environment
+  attr_accessor :message_type
+  attr_accessor :timestamp
+  attr_accessor :token
+  attr_accessor :signature
+
+  validates :timestamp, presence: true
+  validates :token, presence: true
+  validates :signature, presence: true
+  validates :event, presence: true
+  validates :appointment_id, presence: true
+  validates :message_type, presence: true
+  validates :environment, inclusion: { in: %w[production] }
+
+  def create_activity
+    return unless valid?
+
+    verify_token!
+
+    DropActivity.create!(
+      message: "#{message_type.to_s.humanize.downcase} - #{description}",
+      appointment: appointment
+    )
+  end
+
+  private
+
+  def appointment
+    Appointment.find(appointment_id)
+  end
+
+  # rubocop:disable Style/GuardClause
+  def verify_token!
+    digest = OpenSSL::Digest::SHA256.new
+    data   = timestamp + token
+    hex    = OpenSSL::HMAC.hexdigest(digest, api_token, data)
+
+    unless ActiveSupport::SecurityUtils.secure_compare(signature, hex)
+      raise TokenVerificationFailure
+    end
+  end
+
+  def api_token
+    ENV['MAILGUN_API_TOKEN']
+  end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,5 @@
 class Activity < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :appointment
 
   default_scope { order(created_at: :desc) }

--- a/app/models/drop_activity.rb
+++ b/app/models/drop_activity.rb
@@ -1,0 +1,2 @@
+class DropActivity < Activity
+end

--- a/app/views/activities/_drop_activity.html.erb
+++ b/app/views/activities/_drop_activity.html.erb
@@ -1,0 +1,12 @@
+<li
+  class="activity list-group-item t-activity <%= 't-hidden-activity activity--hideable activity--hide' if hide %>"
+  data-activity-id="<%= drop_activity.id %>">
+  <div class="activity__inner">
+    <span class="glyphicon glyphicon-exclamation-sign text-danger" aria-hidden="true"></span>
+    <strong>The system</strong>
+    reported a delivery failure: <em><%= drop_activity.message %></em>
+    <span class="activity__date">
+      <%= drop_activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(drop_activity.created_at.in_time_zone('London'))%> ago)
+    </span>
+  </div>
+</li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   root 'home#index'
 
+  namespace :mailgun do
+    resources :drops, only: :create
+  end
+
   resource :user, only: %i[edit update]
 
   namespace :api, defaults: { format: :json } do

--- a/spec/lib/drop_form_spec.rb
+++ b/spec/lib/drop_form_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe DropForm, '#create_activity' do
+  let(:appointment) { create(:appointment, :with_slot) }
+  let(:params) do
+    {
+      'event'          => 'dropped',
+      'description'    => 'the reasoning',
+      'appointment_id' => appointment.to_param,
+      'environment'    => 'production',
+      'message_type'   => 'confirmation',
+      'timestamp'      => '1474638633',
+      'token'          => 'secret',
+      'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    }
+  end
+  let(:token) { 'deadbeef' }
+
+  around do |example|
+    begin
+      existing = ENV['MAILGUN_API_TOKEN']
+
+      ENV['MAILGUN_API_TOKEN'] = token
+      example.run
+    ensure
+      ENV['MAILGUN_API_TOKEN'] = existing
+    end
+  end
+
+  subject { described_class.new(params) }
+
+  context 'when the signature is not verified' do
+    it 'raises an error' do
+      params['signature'] = 'whoops'
+
+      expect { subject.create_activity }.to raise_error(TokenVerificationFailure)
+    end
+  end
+
+  context 'when the signature is verified' do
+    it 'requires production environment' do
+      params['environment'] = 'staging'
+
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires an event' do
+      params.delete('event')
+
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires an appointment' do
+      params['appointment_id'] = '999'
+
+      expect { subject.create_activity }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'requires a message type' do
+      params.delete('message_type')
+
+      expect(subject).not_to be_valid
+    end
+
+    context 'when everything is validated' do
+      it 'creates the drop activity' do
+        subject.create_activity
+
+        expect(DropActivity.last).to have_attributes(
+          message: 'confirmation - the reasoning',
+          appointment: appointment
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /mailgun/drops' do
+  scenario 'inbound hooks create activity entries' do
+    with_a_configured_token('deadbeef') do
+      given_an_appointment
+      when_mailgun_posts_a_drop_notification
+      then_an_activity_is_created
+      and_the_service_responds_ok
+    end
+  end
+
+  def with_a_configured_token(token)
+    existing = ENV['MAILGUN_API_TOKEN']
+
+    ENV['MAILGUN_API_TOKEN'] = token
+    yield
+  ensure
+    ENV['MAILGUN_API_TOKEN'] = existing
+  end
+
+  def given_an_appointment
+    @appointment = create(:appointment, :with_slot)
+  end
+
+  def when_mailgun_posts_a_drop_notification
+    post mailgun_drops_path, params: {
+      'event'          => 'dropped',
+      'description'    => 'the reasoning',
+      'environment'    => 'production',
+      'message_type'   => 'confirmation',
+      'appointment_id' => @appointment.to_param,
+      'timestamp'      => '1474638633',
+      'token'          => 'secret',
+      'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    }
+  end
+
+  def then_an_activity_is_created
+    expect(DropActivity.last.appointment).to eq(@appointment)
+  end
+
+  def and_the_service_responds_ok
+    expect(response).to be_success
+  end
+end


### PR DESCRIPTION
This allows us to render notification messages when emails are dropped
or bounced. This is in response to inbound webhook calls from MailGun.