### PR TITLE
Include an `available` flag in locations

### DIFF
--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -10,5 +10,9 @@ class LocationSerializer < ActiveModel::Serializer
     postcode
   ]
 
+  attribute :available do
+    object.slots.available.from_tomorrow.count.positive?
+  end
+
   attribute :windowed_slots, if: -> { instance_options[:include_slots] }
 end

--- a/spec/requests/locations_api_spec.rb
+++ b/spec/requests/locations_api_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'GET /api/v1/locations.json' do
       expect(json.first['name']).to eq(@hq.name)
 
       expect(json.first.keys).to match_array(
-        %w[id name address_line_one address_line_two address_line_three town county postcode]
+        %w[id name address_line_one address_line_two address_line_three town county postcode available]
       )
     end
   end


### PR DESCRIPTION
This signals to the client whether this location is available for
bookings.