### PR TITLE
Allow managers to mark appointments processed

### DIFF
--- a/app/assets/stylesheets/components/_action-buttons.scss
+++ b/app/assets/stylesheets/components/_action-buttons.scss
@@ -1,0 +1,5 @@
+.action-buttons {
+  margin-top: 1.4em;
+  text-align: right;
+  white-space: nowrap;
+}

--- a/app/controllers/processes_controller.rb
+++ b/app/controllers/processes_controller.rb
@@ -1,0 +1,8 @@
+class ProcessesController < ApplicationController
+  def create
+    @appointment = Appointment.find(params[:appointment_id])
+    @appointment.process!(current_user)
+
+    redirect_back notice: 'The appointment was marked as processed.', fallback_location: root_path
+  end
+end

--- a/app/lib/appointment_decorator.rb
+++ b/app/lib/appointment_decorator.rb
@@ -1,4 +1,8 @@
 class AppointmentDecorator < SimpleDelegator
+  def processed
+    object.processed_at? ? 'Yes' : 'No'
+  end
+
   def full_name
     "#{object.first_name} #{object.last_name}"
   end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -25,6 +25,16 @@ class Appointment < ApplicationRecord
   validates :slot, presence: true, uniqueness: true
   validates :type_of_appointment, presence: true
 
+  def process!(by)
+    return if processed_at?
+
+    transaction do
+      touch(:processed_at) # rubocop:disable SkipsModelValidations
+
+      ProcessedActivity.create!(user: by, appointment: self)
+    end
+  end
+
   def handle_cancellation!
     return unless status_previously_changed? && cancelled?
 

--- a/app/models/processed_activity.rb
+++ b/app/models/processed_activity.rb
@@ -1,0 +1,2 @@
+class ProcessedActivity < Activity
+end

--- a/app/views/activities/_processed_activity.html.erb
+++ b/app/views/activities/_processed_activity.html.erb
@@ -1,0 +1,11 @@
+<li
+  class="activity list-group-item t-activity <%= 't-hidden-activity activity--hideable activity--hide' if hide %>"
+  data-activity-id="<%= processed_activity.id %>">
+  <div class="activity__inner">
+    <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+    <strong><%= processed_activity.user.name %></strong> processed the appointment.
+    <span class="activity__date">
+      <%= processed_activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(processed_activity.created_at.in_time_zone('London'))%> ago)
+    </span>
+  </div>
+</li>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -6,10 +6,22 @@
     <li class="active"><%= @appointment.full_name %></li>
   </ol>
 
-  <h1>
-    Manage appointment for <%= @appointment.full_name %><br>
-    <small><%= link_to @appointment.slot, edit_appointment_reschedule_path(@appointment) %></small>
-  </h1>
+  <div class="row">
+    <div class="col-md-7">
+      <h1>
+        Manage appointment for <%= @appointment.full_name %><br>
+        <small><%= link_to @appointment.slot, edit_appointment_reschedule_path(@appointment) %></small>
+      </h1>
+    </div>
+    <div class="col-md-5 action-buttons">
+      <% unless @appointment.processed_at? %>
+        <%= link_to appointment_process_path(@appointment), method: :post, title: 'Mark as processed', class: 'btn btn-info' do %>
+          <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+          <span>Mark as processed</span>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>
 
 <%= render partial: 'activities', locals: { appointment: @appointment } %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -25,6 +25,7 @@
             <th>Room</th>
             <th>Reference</th>
             <th>Status</th>
+            <th>Processed</th>
             <th></th>
           </tr>
         </thead>
@@ -49,6 +50,9 @@
               </td>
               <td>
                 <%= appointment.status %>
+              </td>
+              <td>
+                <%= appointment.processed_at? ? 'Yes' : 'No' %>
               </td>
               <td>
                 <%= link_to('Manage', edit_appointment_path(appointment), class: 'btn btn-info t-manage') %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 require 'sidekiq/web'
 
-Rails.application.routes.draw do
+Rails.application.routes.draw do # rubocop:disable BlockLength
   root 'home#index'
 
   namespace :mailgun do
@@ -19,6 +19,8 @@ Rails.application.routes.draw do
 
   resources :appointments, only: %i[index show edit update] do
     resource :reschedule, only: %i[edit update]
+    resource :process, only: :create
+
     resources :activities, only: :create
   end
 

--- a/db/migrate/20180111162227_add_processed_at_to_appointments.rb
+++ b/db/migrate/20180111162227_add_processed_at_to_appointments.rb
@@ -1,0 +1,5 @@
+class AddProcessedAtToAppointments < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appointments, :processed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171026120139) do
+ActiveRecord::Schema.define(version: 20180111162227) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_stat_statements"
 
   create_table "activities", force: :cascade do |t|
     t.bigint "user_id"
@@ -41,7 +42,15 @@ ActiveRecord::Schema.define(version: 20171026120139) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "reminder_sent_at"
+    t.datetime "processed_at"
     t.index ["slot_id"], name: "index_appointments_on_slot_id", unique: true
+  end
+
+  create_table "assignments", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "delivery_centre_id"
+    t.index ["delivery_centre_id"], name: "index_assignments_on_delivery_centre_id"
+    t.index ["user_id"], name: "index_assignments_on_user_id"
   end
 
   create_table "audits", force: :cascade do |t|
@@ -125,6 +134,8 @@ ActiveRecord::Schema.define(version: 20171026120139) do
   add_foreign_key "activities", "appointments"
   add_foreign_key "activities", "users"
   add_foreign_key "appointments", "slots"
+  add_foreign_key "assignments", "delivery_centres"
+  add_foreign_key "assignments", "users"
   add_foreign_key "delivery_centres", "locations"
   add_foreign_key "slots", "delivery_centres"
   add_foreign_key "slots", "rooms"


### PR DESCRIPTION
Allows the booking managers to mark the appointment as 'processed' when
they've processed the details on their external systems.