### PR TITLE
Allow administrators to 'hide' DC's

### DIFF
--- a/app/controllers/admin/delivery_centres_controller.rb
+++ b/app/controllers/admin/delivery_centres_controller.rb
@@ -14,7 +14,7 @@ module Admin
       @delivery_centre = DeliveryCentre.new(delivery_centre_params)
 
       if @delivery_centre.save
-        redirect_to admin_delivery_centres_path(@delivery_centre), success: 'Delivery centre created.'
+        redirect_to admin_delivery_centres_path, success: 'Delivery centre created.'
       else
         render :new
       end
@@ -28,7 +28,7 @@ module Admin
       @delivery_centre = DeliveryCentre.find(params[:id])
 
       if @delivery_centre.update(delivery_centre_params)
-        redirect_to admin_delivery_centres_path(@delivery_centre), success: 'Delivery centre updated.'
+        redirect_to admin_delivery_centres_path, success: 'Delivery centre updated.'
       else
         render :edit
       end
@@ -37,7 +37,7 @@ module Admin
     private
 
     def delivery_centre_params
-      params.require(:delivery_centre).permit(:name, :reply_to)
+      params.require(:delivery_centre).permit(:name, :reply_to, :hidden)
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   end
 
   def load_delivery_centres
-    @delivery_centres = DeliveryCentre.order(:name).pluck(:name, :id)
+    @delivery_centres = DeliveryCentre.order(:name).visible.pluck(:name, :id)
   end
 end

--- a/app/models/delivery_centre.rb
+++ b/app/models/delivery_centre.rb
@@ -4,4 +4,6 @@ class DeliveryCentre < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates :reply_to, presence: true, email: true
+
+  scope :visible, -> { where(hidden: false) }
 end

--- a/app/views/admin/delivery_centres/_form.html.erb
+++ b/app/views/admin/delivery_centres/_form.html.erb
@@ -8,5 +8,9 @@
       <%= f.label :reply_to %>
       <%= f.email_field :reply_to, class: 'form-control t-reply-to' %>
     </div>
+    <div class="form-group">
+      <%= f.label :hidden %>
+      <%= f.check_box :hidden, class: 't-hidden' %>
+    </div>
   </div>
 </div>

--- a/app/views/admin/delivery_centres/index.html.erb
+++ b/app/views/admin/delivery_centres/index.html.erb
@@ -20,6 +20,7 @@
           <tr class="table-header">
             <th>Name</th>
             <th>Booking managers</th>
+            <th>Hidden</th>
             <th>Modified</th>
             <th></th>
           </tr>
@@ -32,6 +33,10 @@
               </td>
               <td>
                 <%= delivery_centre.users.pluck(:name).to_sentence %>
+              </td>
+              <td>
+                <%= delivery_centre.hidden ? 'Yes' : 'No' %>
+              </td>
               <td>
                 <%= time_ago_in_words(delivery_centre.updated_at) %> ago
               </td>

--- a/db/migrate/20180301154357_add_hidden_to_delivery_centres.rb
+++ b/db/migrate/20180301154357_add_hidden_to_delivery_centres.rb
@@ -1,0 +1,5 @@
+class AddHiddenToDeliveryCentres < ActiveRecord::Migration[5.1]
+  def change
+    add_column :delivery_centres, :hidden, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180205162025) do
+ActiveRecord::Schema.define(version: 20180301154357) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20180205162025) do
     t.datetime "updated_at", null: false
     t.string "name", default: "", null: false
     t.string "reply_to", default: "", null: false
+    t.boolean "hidden", default: false, null: false
   end
 
   create_table "locations", force: :cascade do |t|

--- a/spec/factories/delivery_centres.rb
+++ b/spec/factories/delivery_centres.rb
@@ -2,6 +2,11 @@ FactoryBot.define do
   factory :delivery_centre do
     sequence(:name) { |n| "Delivery Centre #{n}" }
     reply_to 'dc@example.com'
+    hidden false
+
+    trait :hidden do
+      hidden true
+    end
 
     trait :with_locations do
       after(:build) { |dc| dc.locations << build(:location) }

--- a/spec/features/booking_manager_assigns_their_delivery_centre_spec.rb
+++ b/spec/features/booking_manager_assigns_their_delivery_centre_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Booking manager assigns their delivery centre' do
 
   def and_a_delivery_centre_exists
     @delivery_centre = create(:delivery_centre)
+    @hidden_delivery_centre = create(:delivery_centre, :hidden, name: 'Hidden DC')
   end
 
   def when_they_visit_the_application
@@ -26,6 +27,8 @@ RSpec.feature 'Booking manager assigns their delivery centre' do
   end
 
   def and_they_choose_a_delivery_centre
+    expect(page).to have_no_content('Hidden DC')
+
     page.find('.t-delivery-centres').select(@delivery_centre.name)
     page.find('.t-submit').click
   end


### PR DESCRIPTION
Lets admins mark old DC's as hidden to ensure new booking managers
cannot self-assign to them.