### PR TITLE
Configure email delivery

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,7 +77,8 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   }
 
   # Configure email delivery method
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries  = ENV['PERFORM_MAILER_DELIVERIES'].present?
+  config.action_mailer.delivery_method     = :smtp
   config.action_mailer.default_url_options = { host: ENV.fetch('APPLICATION_HOST') }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
Allows us to enable/disable email delivery in the production and staging
environments. This helps us ensure staging resource managers do not
receive emails when test bookings are placed.