### PR TITLE
Ensure routed bounces do not attempt to notify

### DIFF
--- a/app/controllers/mailgun/drops_controller.rb
+++ b/app/controllers/mailgun/drops_controller.rb
@@ -2,7 +2,7 @@ module Mailgun
   class DropsController < ActionController::Base
     def create
       @activity = DropForm.new(drop_params).create_activity
-      PusherNotificationJob.perform_later(@activity)
+      PusherNotificationJob.perform_later(@activity) if @activity
 
       head :ok
     end

--- a/spec/features/appointment_reminder_spec.rb
+++ b/spec/features/appointment_reminder_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 RSpec.feature 'Appointment reminders' do
   scenario 'Sending scheduled appointment reminders' do
-    given_an_appointment_exists_and_is_due_a_reminder
-    when_the_scheduled_job_runs
-    then_the_reminder_is_sent
-    and_the_appointment_is_marked_as_reminded
+    perform_enqueued_jobs do
+      given_an_appointment_exists_and_is_due_a_reminder
+      when_the_scheduled_job_runs
+      then_the_reminder_is_sent
+      and_the_appointment_is_marked_as_reminded
+    end
   end
 
   def given_an_appointment_exists_and_is_due_a_reminder

--- a/spec/features/booking_manager_creates_activities_spec.rb
+++ b/spec/features/booking_manager_creates_activities_spec.rb
@@ -2,12 +2,14 @@ require 'rails_helper'
 
 RSpec.feature 'Booking manager creates activities' do
   scenario 'Creating a message activity', js: true do
-    given_the_user_is_identified_as_a_booking_manager do
-      and_there_is_an_appointment
-      when_they_view_the_appointment
-      and_they_leave_a_message
-      then_they_see_their_new_message
-      and_the_message_field_is_cleared
+    perform_enqueued_jobs do
+      given_the_user_is_identified_as_a_booking_manager do
+        and_there_is_an_appointment
+        when_they_view_the_appointment
+        and_they_leave_a_message
+        then_they_see_their_new_message
+        and_the_message_field_is_cleared
+      end
     end
   end
 

--- a/spec/features/booking_manager_manages_an_appointment_spec.rb
+++ b/spec/features/booking_manager_manages_an_appointment_spec.rb
@@ -19,11 +19,13 @@ RSpec.feature 'Booking manager manages an appointment' do
   end
 
   scenario 'Cancelling an appointment' do
-    given_the_user_is_identified_as_a_booking_manager do
-      and_they_have_an_associated_appointment
-      when_the_appointment_is_cancelled
-      then_the_customer_is_notified
-      and_the_original_slot_is_still_available
+    perform_enqueued_jobs do
+      given_the_user_is_identified_as_a_booking_manager do
+        and_they_have_an_associated_appointment
+        when_the_appointment_is_cancelled
+        then_the_customer_is_notified
+        and_the_original_slot_is_still_available
+      end
     end
   end
 

--- a/spec/features/booking_manager_reschedules_appointment_spec.rb
+++ b/spec/features/booking_manager_reschedules_appointment_spec.rb
@@ -2,13 +2,15 @@ require 'rails_helper'
 
 RSpec.feature 'Booking manager reschedules appointment' do
   scenario 'Successfully rescheduling an appointment' do
-    travel_to '2017-09-21 13:00UTC' do
-      given_the_user_is_identified_as_a_booking_manager do
-        and_an_appointment_exists
-        and_another_slot_exists
-        when_they_reschedule_the_appointment
-        then_the_appointment_is_rescheduled
-        and_the_customer_is_notified
+    perform_enqueued_jobs do
+      travel_to '2017-09-21 13:00UTC' do
+        given_the_user_is_identified_as_a_booking_manager do
+          and_an_appointment_exists
+          and_another_slot_exists
+          when_they_reschedule_the_appointment
+          then_the_appointment_is_rescheduled
+          and_the_customer_is_notified
+        end
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include FactoryBot::Syntax::Methods
   config.include UserHelpers
+  config.include ActiveJob::TestHelper
 
   config.after(:each) { ActionMailer::Base.deliveries.clear }
 end

--- a/spec/requests/external_appointment_api_spec.rb
+++ b/spec/requests/external_appointment_api_spec.rb
@@ -11,14 +11,16 @@ RSpec.describe 'POST /api/v1/locations/:location_id/appointments' do
   end
 
   scenario 'Creating a valid appointment' do
-    travel_to '2017-09-12 13:00 UTC' do
-      given_a_location_with_availability
-      when_an_appointment_request_is_made
-      then_the_service_responds_created
-      and_the_appointment_is_identified_in_the_response
-      and_the_appointment_is_created
-      and_the_booking_managers_are_notified
-      and_the_customer_is_notified
+    perform_enqueued_jobs do
+      travel_to '2017-09-12 13:00 UTC' do
+        given_a_location_with_availability
+        when_an_appointment_request_is_made
+        then_the_service_responds_created
+        and_the_appointment_is_identified_in_the_response
+        and_the_appointment_is_created
+        and_the_booking_managers_are_notified
+        and_the_customer_is_notified
+      end
     end
   end
 

--- a/spec/requests/mailgun_drop_notification_spec.rb
+++ b/spec/requests/mailgun_drop_notification_spec.rb
@@ -1,12 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe 'POST /mailgun/drops' do
+  scenario 'inbound hooks from routed mails do not create activity entries' do
+    with_a_configured_token('deadbeef') do
+      perform_enqueued_jobs do
+        given_an_appointment
+        when_mailgun_posts_a_routed_drop_notification
+        then_pusher_is_not_notified
+        and_the_service_responds_ok
+      end
+    end
+  end
+
   scenario 'inbound hooks create activity entries' do
     with_a_configured_token('deadbeef') do
-      given_an_appointment
-      when_mailgun_posts_a_drop_notification
-      then_an_activity_is_created
-      and_the_service_responds_ok
+      perform_enqueued_jobs do
+        given_an_appointment
+        when_mailgun_posts_a_drop_notification
+        then_an_activity_is_created
+        and_pusher_is_notified
+        and_the_service_responds_ok
+      end
     end
   end
 
@@ -38,6 +52,24 @@ RSpec.describe 'POST /mailgun/drops' do
 
   def then_an_activity_is_created
     expect(DropActivity.last.appointment).to eq(@appointment)
+  end
+
+  def when_mailgun_posts_a_routed_drop_notification
+    post mailgun_drops_path, params: {
+      'event'          => 'dropped',
+      'description'    => 'the reasoning',
+      'timestamp'      => '1474638633',
+      'token'          => 'secret',
+      'signature'      => 'abf02bef01e803bea52213cb092a31dc2174f63bcc2382ba25732f4c84e084c1'
+    }
+  end
+
+  def then_pusher_is_not_notified
+    assert_no_performed_jobs
+  end
+
+  def and_pusher_is_notified
+    assert_performed_jobs(1)
   end
 
   def and_the_service_responds_ok


### PR DESCRIPTION
These do not have the necessary contextual attributes (appointment ID,
environment and such) to tie-up with an appointment thus the activity
cannot be created and assigned.