### PR TITLE
Display the location name

### DIFF
--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -90,8 +90,14 @@
                 <%= appointment.processed_at? ? 'Yes' : 'No' %>
               </td>
               <td>
-                <%= link_to('Manage', edit_appointment_path(appointment), class: 'btn btn-info t-manage') %>
-                <%= link_to('Reschedule', edit_appointment_reschedule_path(appointment), class: 'btn btn-info t-reschedule') %>
+                <%= link_to(edit_appointment_path(appointment), title: 'Manage', class: 'btn btn-info t-manage') do %>
+                  <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+                  <span class="sr-only">Manage</span>
+                <% end %>
+                <%= link_to(edit_appointment_reschedule_path(appointment), title: 'Reschedule', class: 'btn btn-info t-reschedule') do %>
+                  <span class="glyphicon glyphicon-repeat" aria-hidden="true"></span>
+                  <span class="sr-only">Reschedule</span>
+                <% end %>
               </td>
             </tr>
           <% end %>

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -57,7 +57,7 @@
             <th>Requested</th>
             <th>Customer name</th>
             <th>Slot</th>
-            <th>Room</th>
+            <th>Location</th>
             <th>Reference</th>
             <th>Status</th>
             <th>Processed</th>
@@ -78,7 +78,7 @@
                 <%= appointment.slot %>
               </td>
               <td>
-                <%= appointment.room %>
+                <%= appointment.location_name %>
               </td>
               <td>
                 <%= appointment.id %>


### PR DESCRIPTION
It makes more sense to display the location name rather than the associated
room since most rooms will simply be the default for the given location.