### PR TITLE
Prepare for GDPR compliance

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -3,6 +3,8 @@ module Api
     class AppointmentsController < ActionController::Base
       include LogrageFilterer
 
+      wrap_parameters false
+
       def create
         @appointment = Appointment.new(appointment_params.merge(slot: slot))
 
@@ -25,7 +27,7 @@ module Api
           :memorable_word,
           :date_of_birth,
           :dc_pot_confirmed,
-          :opt_out_of_market_research
+          :gdpr_consent
         )
       end
 

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -66,7 +66,7 @@ class AppointmentsController < ApplicationController
         :status,
         :date_of_birth,
         :dc_pot_confirmed,
-        :opt_out_of_market_research
+        :gdpr_consent
       )
   end
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -24,6 +24,7 @@ class Appointment < ApplicationRecord
   validates :date_of_birth, presence: true
   validates :slot, presence: true, uniqueness: true
   validates :type_of_appointment, presence: true
+  validates :gdpr_consent, inclusion: { in: ['yes', 'no', ''] }
 
   scope :by_delivery_centre, lambda { |delivery_centre|
     includes(slot: { room: :location })

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -87,9 +87,29 @@
               Don’t know
             <% end %>
           </div>
+
+          <h2 class="h3">Research</h2>
           <div class="form-group">
-            <%= f.label :opt_out_of_market_research %>
-            <%= f.check_box :opt_out_of_market_research, class: 't-opt-out-of-market-research' %>
+            <p><strong>Customer research consent</strong></p>
+            <p class="help-block">
+              Your feedback helps us improve the service. Is it OK if we share your
+              contact details with our trusted research partner? Ipsos MORI may
+              contact you to ask if you would like to provide feedback and you can
+              decide then if you want to take part.
+            </p>
+
+            <%= f.label :gdpr_consent, value: 'yes', class: 'radio-inline' do %>
+              <%= f.radio_button :gdpr_consent, 'yes', class: 't-gdpr-consent-yes' %>
+              Yes
+            <% end %>
+            <%= f.label :gdpr_consent, value: 'no', class: 'radio-inline' do %>
+              <%= f.radio_button :gdpr_consent, 'no', class: 't-gdpr-consent-no' %>
+              No
+            <% end %>
+            <%= f.label :gdpr_consent, value: '', class: 'radio-inline' do %>
+              <%= f.radio_button :gdpr_consent, '', class: 't-gdpr-consent-no-response' %>
+              No response
+            <% end %>
           </div>
         </div>
       </div>

--- a/db/migrate/20180520134037_add_gdpr_consent_to_appointments.rb
+++ b/db/migrate/20180520134037_add_gdpr_consent_to_appointments.rb
@@ -1,0 +1,23 @@
+class AddGdprConsentToAppointments < ActiveRecord::Migration[5.1]
+  def up
+    add_column :appointments, :gdpr_consent, :string, null: false, default: ''
+
+    Appointment.reset_column_information
+
+    Appointment.where(opt_out_of_market_research: true).update_all(gdpr_consent: 'no')
+    Appointment.where(opt_out_of_market_research: false).update_all(gdpr_consent: 'yes')
+
+    remove_column :appointments, :opt_out_of_market_research
+  end
+
+  def down
+    add_column :appointments, :opt_out_of_market_research, :boolean, null: false, default: false
+
+    Appointment.reset_column_information
+
+    Appointment.where(gdpr_consent: ['yes', '']).update_all(opt_out_of_market_research: false)
+    Appointment.where(gdpr_consent: 'no').update_all(opt_out_of_market_research: true)
+
+    remove_column :appointments, :gdpr_consent
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180301154357) do
+ActiveRecord::Schema.define(version: 20180520134037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,12 +37,12 @@ ActiveRecord::Schema.define(version: 20180301154357) do
     t.string "type_of_appointment", null: false
     t.date "date_of_birth", null: false
     t.integer "status", default: 0, null: false
-    t.boolean "opt_out_of_market_research", default: false, null: false
     t.boolean "dc_pot_confirmed", default: true, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "reminder_sent_at"
     t.datetime "processed_at"
+    t.string "gdpr_consent", default: "", null: false
     t.index ["slot_id"], name: "index_appointments_on_slot_id", unique: true
   end
 

--- a/spec/factories/appointments.rb
+++ b/spec/factories/appointments.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     last_name 'Sanchez'
     email 'rick@example.com'
     phone '0208 252 4758'
-    opt_out_of_market_research true
+    gdpr_consent 'yes'
     dc_pot_confirmed true
     memorable_word 'snootbooper'
     date_of_birth '1945-01-01'

--- a/spec/features/booking_manager_manages_an_appointment_spec.rb
+++ b/spec/features/booking_manager_manages_an_appointment_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Booking manager manages an appointment' do
     @page.phone.set '07715 999 1234'
     @page.memorable_word.set 'spaceboot'
     @page.status.select 'No Show'
-    @page.opt_out_of_market_research.set false
+    @page.gdpr_consent_no.set true
     @page.dc_pot_confirmed_dont_know.set true
 
     @page.submit.click
@@ -61,7 +61,7 @@ RSpec.feature 'Booking manager manages an appointment' do
       phone: '07715 999 1234',
       memorable_word: 'spaceboot',
       status: 'no_show',
-      opt_out_of_market_research: false,
+      gdpr_consent: 'no',
       dc_pot_confirmed: false
     )
   end

--- a/spec/requests/external_appointment_api_spec.rb
+++ b/spec/requests/external_appointment_api_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'POST /api/v1/locations/:location_id/appointments' do
       'memorable_word'   => 'snootboop',
       'date_of_birth'    => '1950-02-02',
       'dc_pot_confirmed' => true,
-      'opt_out_of_market_research' => true
+      'gdpr_consent'     => 'yes'
     }
 
     path = api_v1_location_appointments_path(location_id: @location.id)
@@ -74,7 +74,7 @@ RSpec.describe 'POST /api/v1/locations/:location_id/appointments' do
       type_of_appointment: '55-plus',
       date_of_birth: Date.parse('1950-02-02'),
       dc_pot_confirmed: true,
-      opt_out_of_market_research: true,
+      gdpr_consent: 'yes',
       status: 'pending'
     )
   end

--- a/spec/support/pages/appointment.rb
+++ b/spec/support/pages/appointment.rb
@@ -17,7 +17,9 @@ module Pages
     element :year_of_birth, '.t-date-of-birth-year'
     element :dc_pot_confirmed_yes, '.t-dc-pot-confirmed-yes'
     element :dc_pot_confirmed_dont_know, '.t-dc-pot-confirmed-dont-know'
-    element :opt_out_of_market_research, '.t-opt-out-of-market-research'
+    element :gdpr_consent_yes, '.t-gdpr-consent-yes'
+    element :gdpr_consent_no, '.t-gdpr-consent-no'
+    element :gdpr_consent_no_response, '.t-gdpr-consent-no-response'
 
     element :submit, '.t-submit'
 


### PR DESCRIPTION
Ensures existing and new appointments are tagged with the customer's
consent for contact. The migration will move away (or back) to the
previous marketing `opt_out_of_market_research` flag.