### PR TITLE
Resolve issues displaying 'orphaned' activities

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -5,4 +5,8 @@ class Activity < ApplicationRecord
   def to_partial_path
     "activities/#{model_name.singular}"
   end
+
+  def owner
+    user ? user.name : 'Someone'
+  end
 end

--- a/app/views/activities/_message_activity.html.erb
+++ b/app/views/activities/_message_activity.html.erb
@@ -3,7 +3,7 @@
   data-activity-id="<%= message_activity.id %>">
   <div class="activity__inner">
     <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
-    <strong><%= message_activity.user.name %></strong> said <em><%= message_activity.message %></em>
+    <strong><%= message_activity.owner %></strong> said <em><%= message_activity.message %></em>
     <span class="activity__date">
       <%= message_activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(message_activity.created_at.in_time_zone('London'))%> ago)
     </span>

--- a/app/views/activities/_processed_activity.html.erb
+++ b/app/views/activities/_processed_activity.html.erb
@@ -3,7 +3,7 @@
   data-activity-id="<%= processed_activity.id %>">
   <div class="activity__inner">
     <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
-    <strong><%= processed_activity.user.name %></strong> processed the appointment.
+    <strong><%= processed_activity.owner %></strong> processed the appointment.
     <span class="activity__date">
       <%= processed_activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(processed_activity.created_at.in_time_zone('London'))%> ago)
     </span>


### PR DESCRIPTION
When the owning user isn't present this errors currently. This change
ensures we display the activity in these instances but attribute them
to 'Someone'.