### PR TITLE
Ensure `current_user` is always populated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   include LogrageFilterer
 
+  before_action :authenticate_user!
+
   protect_from_forgery with: :exception
 
   add_flash_types :success, :notice, :warning


### PR DESCRIPTION
In those cases where subclasses do not explicitly assert on particular
user permissions we should ensure `authenticate_user!` is called to
populate the `current_user`.