### PR TITLE
Rake task to disable live locations

### DIFF
--- a/lib/tasks/locations.rake
+++ b/lib/tasks/locations.rake
@@ -1,0 +1,6 @@
+namespace :locations do
+  desc 'Disable bookings for all locations'
+  task disable: :environment do
+    Location.active.update_all(active: false) # rubocop:disable SkipsModelValidations
+  end
+end


### PR DESCRIPTION
When run, this will disable all currently 'active' locations thus no
longer allowing bookings.