### PR TITLE
Instant appointment search

### DIFF
--- a/app/assets/javascripts/modules/quick-search.es6
+++ b/app/assets/javascripts/modules/quick-search.es6
@@ -1,0 +1,21 @@
+'use strict';
+
+{
+  class QuickSearch {
+    start(el) {
+      this.$el = $(el);
+      this.$button = this.$el.find('.js-quick-search-button');
+      this.$input = this.$el.find('.js-quick-search-input');
+
+      this.bindEvents();
+    }
+
+    bindEvents() {
+      this.$button.on('click', () => {
+        setTimeout(() => this.$input.focus(), 0); // next tick
+      });
+    }
+  }
+
+  window.GOVUKAdmin.Modules.QuickSearch = QuickSearch;
+}

--- a/app/assets/stylesheets/components/_quick-search.scss
+++ b/app/assets/stylesheets/components/_quick-search.scss
@@ -1,0 +1,13 @@
+.quick-search__dropdown {
+  box-sizing: border-box;
+  padding: 8px;
+  white-space: nowrap;
+}
+
+.quick-search__input {
+  font-weight: normal;
+}
+
+.quick-search__label {
+  margin-bottom: 0;
+}

--- a/app/controllers/admin/appointments_controller.rb
+++ b/app/controllers/admin/appointments_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class AppointmentsController < ApplicationController
+    before_action :authorise_administrator!
+
+    def index
+      if @appointment = Appointment.find_by(id: params[:id]) # rubocop:disable AssignmentInCondition
+        reassign_delivery_centre(@appointment)
+
+        redirect_to edit_appointment_path(@appointment)
+      else
+        redirect_back warning: "The appointment '#{params[:id]}' could not be found.", fallback_location: root_path
+      end
+    end
+
+    private
+
+    def reassign_delivery_centre(appointment)
+      current_user.assign!(appointment.delivery_centre)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,12 @@ class User < ApplicationRecord
 
   scope :active, -> { where(disabled: false) }
 
+  def assign!(dc)
+    return if dc.id == delivery_centre_id
+
+    update!(delivery_centre: dc)
+  end
+
   def location
     return unless delivery_centre_id?
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,11 +14,32 @@
   <% end %>
   <% if current_user.administrator? %>
     <li class="dropdown">
-      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Administration <span class="caret"></span></a>
+      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+        <span class="sr-only">Administration</span>
+        <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>
+        <span class="caret"></span>
+      </a>
       <ul class="dropdown-menu">
         <li><%= link_to 'Locations', admin_locations_path %></li>
         <li><%= link_to 'Delivery Centres', admin_delivery_centres_path %></li>
       </ul>
+    </li>
+    <li class="dropdown quick-search t-quick-search" data-module="quick-search">
+      <a href="#" class="dropdown-toggle js-quick-search-button" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+        <span class="sr-only">Find an appointment by reference</span>
+        <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+        <span class="caret"></span>
+      </a>
+      <div class="dropdown-menu quick-search__dropdown">
+        <form method="get" action="/admin/appointments" class="form-inline">
+          <div class="form-group quick-search__form-group">
+            <label for="quick-search-input" class="quick-search__label"><span class="sr-only">Appointment ID</span>
+              <input type="text" id="quick-search-input" class="form-control input-sm quick-search__input js-quick-search-input" name="id" placeholder="Reference">
+            </label>
+          </div>
+          <input type="submit" class="quick-search__button btn btn-primary btn-xs t-quick-search-button" value="Search">
+        </form>
+      </div>
     </li>
     <li>
       <%= form_for current_user, html: { class: 'navbar-form navbar-right js-delivery-centre-form' } do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
     end
   end
 
-  resources :appointments, only: %i[index show edit update] do
+  resources :appointments, only: %i[index edit update] do
     resource :reschedule, only: %i[edit update]
     resource :process, only: :create
 
@@ -35,6 +35,7 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
     resources :locations do
       resources :rooms
     end
+    resources :appointments, only: :index
   end
 
   mount Sidekiq::Web, at: '/sidekiq', constraints: AuthenticatedUser.new

--- a/spec/features/administrator_searches_for_an_appointment_spec.rb
+++ b/spec/features/administrator_searches_for_an_appointment_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.feature 'Administrator searches for an appointment by reference' do
+  scenario 'Viewing an appointment', js: true do
+    given_the_user_is_identified_as_an_administrator do
+      when_they_search_for_an_appointment
+      then_they_are_presented_with_the_appointment
+    end
+  end
+
+  scenario 'Attempting to search when not an administrator' do
+    given_the_user_is_identified_as_a_booking_manager do
+      they_do_not_see_the_quick_search
+    end
+  end
+
+  def they_do_not_see_the_quick_search
+    visit '/'
+
+    expect(page).to have_no_css('.t-quick-search')
+  end
+
+  def when_they_search_for_an_appointment
+    @appointment = create(:appointment, :with_slot)
+
+    visit '/'
+    find(:css, '.t-quick-search').click
+    fill_in 'quick-search-input', with: @appointment.id
+    find(:css, '.t-quick-search-button').click
+  end
+
+  def then_they_are_presented_with_the_appointment
+    expect(page.current_path).to eq(edit_appointment_path(@appointment))
+  end
+end


### PR DESCRIPTION
As an administrator it's annoying having to figure out which delivery
centre you ought to belong to in order to find a booking by its
reference number. This quick search box will automatically switch you
to the correct delivery centre where necessary.