### PR TITLE
Do not send reminders for bookings on same days

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -31,6 +31,8 @@ class Appointment < ApplicationRecord
       .where(locations: { delivery_centre_id: delivery_centre.id })
   }
 
+  scope :not_booked_today, -> { where.not(created_at: Time.current.beginning_of_day..Time.current.end_of_day) }
+
   delegate :location, to: :room
   delegate :delivery_centre, to: :location
 
@@ -65,6 +67,7 @@ class Appointment < ApplicationRecord
 
   def self.needing_reminder
     pending
+      .not_booked_today
       .joins(:slot)
       .where(reminder_sent_at: nil)
       .where(slots: { start_at: Time.current..48.hours.from_now })

--- a/spec/features/appointment_reminder_spec.rb
+++ b/spec/features/appointment_reminder_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Appointment reminders' do
   end
 
   def given_an_appointment_exists_and_is_due_a_reminder
-    @appointment      = build(:appointment)
+    @appointment      = build(:appointment, created_at: 1.day.ago)
     @appointment.slot = build(:slot, :with_room, start_at: 36.hours.from_now)
 
     @appointment.save!


### PR DESCRIPTION
This change ensures we never send reminders on the same day bookings
are placed. The customer will always receive confirmation after booking
so same-day reminders are obviously redundant.