### PR TITLE
Send SMS reminders 48 hours before an appointment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ source 'https://rubygems.org' do
   gem 'govuk_admin_template'
   gem 'kaminari'
   gem 'momentjs-rails'
+  gem 'notifications-ruby-client'
   gem 'pg', '~> 0.18'
   gem 'plek'
   gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,8 @@ GEM
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
+    notifications-ruby-client (2.6.0)
+      jwt (>= 1.5, < 3)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
       jwt (~> 1.0)
@@ -402,6 +404,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)!
   lograge!
   momentjs-rails!
+  notifications-ruby-client!
   pg (~> 0.18)!
   phantomjs!
   plek!

--- a/app/jobs/sms_appointment_reminder_job.rb
+++ b/app/jobs/sms_appointment_reminder_job.rb
@@ -1,0 +1,43 @@
+require 'notifications/client'
+
+class SmsAppointmentReminderJob < ApplicationJob
+  queue_as :default
+
+  TEMPLATE_ID = 'd7dcd977-f3fa-42a5-a5ca-110d0ac8e05e'.freeze
+
+  rescue_from(Notifications::Client::RequestError) do |exception|
+    Bugsnag.notify(exception)
+  end
+
+  def perform(appointment)
+    return unless api_key
+
+    send_sms_reminder(appointment)
+
+    SmsReminderActivity.from(appointment)
+  end
+
+  private
+
+  def send_sms_reminder(appointment)
+    appointment = AppointmentDecorator.new(appointment)
+
+    sms_client.send_sms(
+      phone_number: appointment.phone,
+      template_id: TEMPLATE_ID,
+      reference: appointment.to_param,
+      personalisation: {
+        date: appointment.slot,
+        location: appointment.location_name
+      }
+    )
+  end
+
+  def sms_client
+    @sms_client ||= Notifications::Client.new(api_key)
+  end
+
+  def api_key
+    ENV['NOTIFY_API_KEY']
+  end
+end

--- a/app/jobs/sms_appointment_reminders_job.rb
+++ b/app/jobs/sms_appointment_reminders_job.rb
@@ -1,0 +1,9 @@
+class SmsAppointmentRemindersJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Appointment.needing_sms_reminder.find_each do |appointment|
+      SmsAppointmentReminderJob.perform_later(appointment)
+    end
+  end
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -33,6 +33,8 @@ class Appointment < ApplicationRecord
 
   scope :not_booked_today, -> { where.not(created_at: Time.current.beginning_of_day..Time.current.end_of_day) }
 
+  scope :with_mobile, -> { where("phone like '07%'") }
+
   delegate :location, to: :room
   delegate :delivery_centre, to: :location
 
@@ -71,6 +73,12 @@ class Appointment < ApplicationRecord
       .joins(:slot)
       .where(reminder_sent_at: nil)
       .where(slots: { start_at: Time.current..48.hours.from_now })
+  end
+
+  def self.needing_sms_reminder
+    two_day_range = 48.hours.from_now.beginning_of_day..48.hours.from_now.end_of_day
+
+    pending.not_booked_today.with_mobile.joins(:slot).where(slots: { start_at: two_day_range })
   end
 
   private

--- a/app/models/sms_reminder_activity.rb
+++ b/app/models/sms_reminder_activity.rb
@@ -1,0 +1,5 @@
+class SmsReminderActivity < Activity
+  def self.from(appointment)
+    create!(appointment: appointment)
+  end
+end

--- a/app/views/activities/_sms_reminder_activity.html.erb
+++ b/app/views/activities/_sms_reminder_activity.html.erb
@@ -1,0 +1,11 @@
+<li
+  class="activity list-group-item t-activity <%= 't-hidden-activity activity--hideable activity--hide' if hide %>"
+  data-activity-id="<%= sms_reminder_activity.id %>">
+  <div class="activity__inner">
+    <span class="glyphicon glyphicon-phone" aria-hidden="true"></span>
+    <strong>The system</strong> sent an appointment reminder SMS to the customer
+    <span class="activity__date">
+      <%= sms_reminder_activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(sms_reminder_activity.created_at.in_time_zone('London'))%> ago)
+    </span>
+  </div>
+</li>

--- a/spec/features/sms_appointment_reminder_spec.rb
+++ b/spec/features/sms_appointment_reminder_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.feature 'SMS appointment reminders' do
+  scenario 'Executing the SMS appointment reminders job' do
+    travel_to '2018-05-28 08:00 UTC' do
+      given_appointments_due_sms_reminders_exist
+      when_the_task_is_executed
+      then_the_required_jobs_are_scheduled
+    end
+  end
+
+  def given_appointments_due_sms_reminders_exist
+    @user = create(:booking_manager)
+    # past the reminder window
+    @past = appointment_for_user(@user, start_at: 5.days.from_now)
+    # in the window but no mobile number
+    @no_mobile = appointment_for_user(@user, phone: '02082524727', start_at: 2.days.from_now)
+    # in the window with a mobile number
+    @mobile = appointment_for_user(@user, phone: '07715930455', start_at: 2.days.from_now)
+  end
+
+  def when_the_task_is_executed
+    SmsAppointmentRemindersJob.perform_now
+  end
+
+  def then_the_required_jobs_are_scheduled
+    assert_enqueued_jobs(1, only: SmsAppointmentReminderJob)
+  end
+end

--- a/spec/jobs/sms_appointment_reminder_job_spec.rb
+++ b/spec/jobs/sms_appointment_reminder_job_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe SmsAppointmentReminderJob, '#perform' do
+  let(:appointment) { create(:appointment, :with_slot, phone: '07715 930 444') }
+  let(:client) { double(Notifications::Client, send_sms: true) }
+
+  it 'sends an SMS' do
+    expect(client).to receive(:send_sms).with(
+      phone_number: '07715 930 444',
+      template_id: SmsAppointmentReminderJob::TEMPLATE_ID,
+      reference: appointment.to_param,
+      personalisation: {
+        date: '2:00pm, 15 June 2018',
+        location: a_string_matching(/\ATesco \d+/)
+      }
+    )
+
+    described_class.new.perform(appointment)
+
+    expect(appointment.activities.first).to be_an(SmsReminderActivity)
+  end
+
+  before do
+    ENV['NOTIFY_API_KEY'] = 'blahblah'
+
+    allow(Notifications::Client).to receive(:new).and_return(client)
+
+    travel_to '2018-06-15 13:00 UTC'
+  end
+
+  after do
+    ENV.delete('NOTIFY_API_KEY')
+
+    travel_back
+  end
+end

--- a/spec/support/user_helpers.rb
+++ b/spec/support/user_helpers.rb
@@ -35,8 +35,11 @@ module UserHelpers
     GDS::SSO.test_user = nil
   end
 
-  def appointment_for_user(user, start_at: Time.current)
-    build(:appointment) do |a|
+  def appointment_for_user(user, **opts)
+    start_at = opts.delete(:start_at) || Time.current
+    opts[:created_at] ||= 1.day.ago
+
+    build(:appointment, opts) do |a|
       a.slot = build(
         :slot,
         start_at: start_at,


### PR DESCRIPTION
If the customer has supplied a mobile number we will send them an
SMS appointment reminder 48 hours before their appointment is due to
take place.