### PR TITLE
Audit appointment changes

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,4 +1,6 @@
 class Appointment < ApplicationRecord
+  audited
+
   belongs_to :slot
   has_one :room, through: :slot
   has_many :activities, -> { order('created_at DESC') }


### PR DESCRIPTION
We've had incidences where audit history for appointments would help
debug problems that have been reported in relation to customer bookings.