### PR TITLE
Guard against duplicate, available slots

### DIFF
--- a/app/models/slot.rb
+++ b/app/models/slot.rb
@@ -1,6 +1,9 @@
 class Slot < ApplicationRecord
   audited
 
+  validates :start_at, :end_at, presence: true
+  validate :check_slot_uniqueness
+
   before_validation :infer_end_at!
 
   belongs_to :room
@@ -27,6 +30,14 @@ class Slot < ApplicationRecord
   end
 
   private
+
+  def check_slot_uniqueness
+    return unless start_at? && room_id?
+
+    if self.class.available.exists?(start_at: start_at, room_id: room_id) # rubocop:disable GuardClause
+      errors.add(:start_at, 'A duplicate, available slot exists')
+    end
+  end
 
   def infer_end_at!
     return if end_at?

--- a/spec/models/slot_spec.rb
+++ b/spec/models/slot_spec.rb
@@ -1,6 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Slot do
+  describe 'Validation' do
+    it 'is valid with valid attributes' do
+      expect(build(:slot, :with_room)).to be_valid
+    end
+
+    it 'validates uniqueness of slots' do
+      travel_to '2018-01-01 13:00' do
+        # Don't allow available duplicates
+        @slot = create(:slot, :with_room)
+        expect(build(:slot, room: @slot.room)).to be_invalid
+
+        # Allow duplicates without availability
+        @appointment = create(:appointment, :with_slot)
+        expect(build(:slot, room: @appointment.room)).to be_valid
+      end
+    end
+  end
+
   describe 'Inferring `end_at`' do
     context 'when `end_at` is not present' do
       it 'is inferred from the `start_at`' do


### PR DESCRIPTION
This change ensures booking managers cannot create multiple, identical
slots (usually by double-clicking the calendar) and therefore allowing
double-booked rooms.