### PR TITLE
Disable button on form submission

### DIFF
--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -115,7 +115,7 @@
       </div>
       <div class="row">
         <div class="col-md-12">
-          <%= f.button class: 'btn btn-primary t-submit' do %>
+          <%= f.button class: 'btn btn-primary t-submit', data: { disable_with: 'Please wait...' } do %>
             Update appointment details for <%= @appointment.full_name %>
           <% end %>
         </div>


### PR DESCRIPTION
Some booking managers double-click the submit button so when cancelling
an appointment the underlying slot will be freed twice, the second time
causing an error to be displayed.