### PR TITLE
Do not allow rescheduling of cancelled appointments

### DIFF
--- a/app/assets/stylesheets/helper/_disabled-link.scss
+++ b/app/assets/stylesheets/helper/_disabled-link.scss
@@ -1,0 +1,8 @@
+.disabled-link {
+  pointer-events: none;
+  color: initial;
+
+  &:visited {
+    color: initial;
+  }
+}

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -28,6 +28,7 @@ class Appointment < ApplicationRecord
   validates :slot, presence: true, uniqueness: true
   validates :type_of_appointment, presence: true
   validates :gdpr_consent, inclusion: { in: ['yes', 'no', ''] }
+  validate :cannot_reschedule_when_cancelled
 
   scope :by_delivery_centre, lambda { |delivery_centre|
     includes(slot: { room: :location })
@@ -119,5 +120,11 @@ class Appointment < ApplicationRecord
     age = Time.zone.today.year - date_of_birth.year
     age -= 1 if Time.zone.today.to_date < date_of_birth + age.years
     age
+  end
+
+  def cannot_reschedule_when_cancelled
+    return unless slot_id_changed? && cancelled?
+
+    errors.add(:slot, 'cannot be rescheduled if cancelled')
   end
 end

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -13,9 +13,7 @@
         <small>
           Booking reference: <%= @appointment.id %><br>
           Location: <%= @appointment.location_name %><br>
-          <% unless @appointment.cancelled? %>
-            <%= link_to @appointment.slot, edit_appointment_reschedule_path(@appointment) %>
-          <% end %>
+          <%= link_to @appointment.slot, edit_appointment_reschedule_path(@appointment), class: (@appointment.cancelled? ? "disabled-link": "") %>
         </small>
       </h1>
     </div>

--- a/app/views/appointments/edit.html.erb
+++ b/app/views/appointments/edit.html.erb
@@ -13,7 +13,9 @@
         <small>
           Booking reference: <%= @appointment.id %><br>
           Location: <%= @appointment.location_name %><br>
-          <%= link_to @appointment.slot, edit_appointment_reschedule_path(@appointment) %>
+          <% unless @appointment.cancelled? %>
+            <%= link_to @appointment.slot, edit_appointment_reschedule_path(@appointment) %>
+          <% end %>
         </small>
       </h1>
     </div>

--- a/spec/features/booking_manager_reschedules_appointment_spec.rb
+++ b/spec/features/booking_manager_reschedules_appointment_spec.rb
@@ -7,6 +7,8 @@ RSpec.feature 'Booking manager reschedules appointment' do
         given_the_user_is_identified_as_a_booking_manager do
           and_an_appointment_exists
           and_another_slot_exists
+          when_they_edit_the_appointment
+          then_they_are_offered_to_reschedule_the_appointment
           when_they_reschedule_the_appointment
           then_the_appointment_is_rescheduled
           and_the_customer_is_notified
@@ -74,8 +76,12 @@ RSpec.feature 'Booking manager reschedules appointment' do
     expect(@page).to have_content('cannot be rescheduled if cancelled')
   end
 
+  def then_they_are_offered_to_reschedule_the_appointment
+    expect(find_link('2:00pm, 21 September 2017')[:class]).to_not include('disabled-link')
+  end
+
   def then_they_are_not_offered_to_reschedule_the_appointment
-    expect(@page).to_not have_link('2:00pm, 21 September 2017', href: edit_appointment_reschedule_path(@appointment))
+    expect(find_link('2:00pm, 21 September 2017')[:class]).to include('disabled-link')
   end
 
   def and_the_customer_is_notified

--- a/spec/features/booking_manager_reschedules_appointment_spec.rb
+++ b/spec/features/booking_manager_reschedules_appointment_spec.rb
@@ -15,8 +15,34 @@ RSpec.feature 'Booking manager reschedules appointment' do
     end
   end
 
+  scenario 'Attempting to reschedule a cancelled appointment' do
+    travel_to '2017-09-21 13:00UTC' do
+      given_the_user_is_identified_as_a_booking_manager do
+        and_a_cancelled_appointment_exists
+        and_another_slot_exists
+        when_they_reschedule_the_appointment
+        then_they_see_a_warning
+      end
+    end
+  end
+
+  scenario 'Not offered to reschedule a cancelled appointment' do
+    travel_to '2017-09-21 13:00UTC' do
+      given_the_user_is_identified_as_a_booking_manager do
+        and_a_cancelled_appointment_exists
+        and_another_slot_exists
+        when_they_edit_the_appointment
+        then_they_are_not_offered_to_reschedule_the_appointment
+      end
+    end
+  end
+
   def and_an_appointment_exists
     @appointment = appointment_for_user(@user)
+  end
+
+  def and_a_cancelled_appointment_exists
+    @appointment = appointment_for_user(@user, status: :cancelled_by_pension_wise)
   end
 
   def and_another_slot_exists
@@ -31,12 +57,25 @@ RSpec.feature 'Booking manager reschedules appointment' do
     @page.submit.click
   end
 
+  def when_they_edit_the_appointment
+    @page = Pages::Appointment.new
+    @page.load(id: @appointment.id)
+  end
+
   def then_the_appointment_is_rescheduled
     @page = Pages::Appointments.new
     expect(@page).to be_displayed
     expect(@page).to have_success
 
     expect(@appointment.reload.slot_id).to eq(@slot.id)
+  end
+
+  def then_they_see_a_warning
+    expect(@page).to have_content('cannot be rescheduled if cancelled')
+  end
+
+  def then_they_are_not_offered_to_reschedule_the_appointment
+    expect(@page).to_not have_link('2:00pm, 21 September 2017', href: edit_appointment_reschedule_path(@appointment))
   end
 
   def and_the_customer_is_notified

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Appointment, 'Validation' do
+  %i[
+    cancelled_by_customer
+    cancelled_by_pension_wise
+    cancelled_by_customer_sms
+  ].each do |status|
+    it "validates an appointment cannot be rescheduled if #{status}" do
+      appointment = build(:appointment, slot_id: 1, status: status)
+
+      appointment.update(slot_id: 2)
+
+      expect(appointment.errors.messages[:slot]).to include('cannot be rescheduled if cancelled')
+    end
+  end
+end


### PR DESCRIPTION
Cancelling an appointment creates a new slot for the same time - the idea
being that the original slot is now redundant. But allowing a cancelled
appointment to be rescheduled makes the slot available for use again.

On 19th Oct 2018 we received a report that a particular room for a
particular time had 3 slots with 1 cancelled appointment and 2 pending
appointments.

The events that led up to that were:

```
At the start.. just 1 slot existed..

1. Appointment 3091 (Ann) for 7/11 cancelled at 12:03 on 15/10
2. Automatically creates a new slot 9086 for 7/11

Currently 2 slots.. (1 available and 1 with a cancelled appointment)

3. Appointment 3502 (Wai) rescheduled to slot 9086 at 12:04 on 15/10

Currently 2 slots.. (1 with a pending appointment and 1 with a cancelled appointment)

4. Appointment 3091 (Ann) rescheduled to slot 2823 for 8/11 at 12:04 on 15/10

Currently 2 slots.. (1 available and 1 with a pending appointment)

5. Appointment 3556 (Rebecca) created to slot 2826 at 18:01 on 15/10

Currently 2 slots.. (2 with pending appointments)

6. Appointment 3556 (Rebecca) cancelled at 14:15:34 on 17/10
7. Automatically creates a new slot 9093 for 7/11

Currently 3 slots.. (1 with cancelled appointment, 1 with pending, 1 available)

8. Appointment 3591 (Nicola) created for slot 9093 at 17:04 on 17/10

Currently 3 slots.. (1 with cancelled appointment, 2 with pending appointments)
```

If 4. hadn't happened, then it wouldn't have been possible to end up
with 2 slots with 2 pending appointments.