### PR TITLE
Don't free slots when already cancelled

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,4 +1,4 @@
-class Appointment < ApplicationRecord
+class Appointment < ApplicationRecord # rubocop:disable ClassLength
   audited
 
   belongs_to :slot
@@ -62,7 +62,7 @@ class Appointment < ApplicationRecord
   end
 
   def handle_cancellation!
-    return unless status_previously_changed? && cancelled?
+    return unless should_cancel?
 
     slot.free!
     yield self
@@ -74,6 +74,13 @@ class Appointment < ApplicationRecord
 
   def cancelled?
     status.start_with?('cancelled')
+  end
+
+  def should_cancel?
+    return unless status_previously_changed? && cancelled?
+    return if status_previous_change.first.to_s.start_with?('cancelled')
+
+    true
   end
 
   def future?

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -14,4 +14,16 @@ RSpec.describe Appointment, 'Validation' do
       expect(appointment.errors.messages[:slot]).to include('cannot be rescheduled if cancelled')
     end
   end
+
+  describe '#should_cancel?' do
+    it 'returns true when the status was not already cancelled' do
+      appointment = create(:appointment, :with_slot)
+
+      appointment.update(status: :cancelled_by_customer)
+      expect(appointment).to be_should_cancel
+
+      appointment.update(status: :cancelled_by_customer_sms)
+      expect(appointment).not_to be_should_cancel
+    end
+  end
 end


### PR DESCRIPTION
There is no real reason a booking manager should move between
'cancelled' statuses but when they do we msust ensure we don't free the
underlying slot again.