### PR TITLE
Email the customer when their details change

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -18,6 +18,7 @@ class AppointmentsController < ApplicationController
   def update
     if @appointment.update(appointment_params)
       handle_cancellation(@appointment)
+      handle_notification(@appointment)
       redirect_to appointments_path, success: 'The appointment was updated.'
     else
       render :edit
@@ -58,6 +59,12 @@ class AppointmentsController < ApplicationController
     appointment.handle_cancellation! do
       AppointmentMailer.cancellation(appointment.object).deliver_later
     end
+  end
+
+  def handle_notification(appointment)
+    return unless appointment.notify?
+
+    AppointmentMailer.customer(appointment.object).deliver_later
   end
 
   def appointment_params # rubocop:disable Metrics/MethodLength

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -42,6 +42,13 @@ class Appointment < ApplicationRecord # rubocop:disable ClassLength
   delegate :location, to: :room
   delegate :delivery_centre, to: :location
 
+  def notify?
+    return false if past? || previous_changes.none?
+    return true  if previous_changes.exclude?(:status)
+
+    previous_changes[:status] && pending?
+  end
+
   def cancel!
     transaction do
       update!(status: :cancelled_by_customer_sms)
@@ -85,6 +92,10 @@ class Appointment < ApplicationRecord # rubocop:disable ClassLength
 
   def future?
     slot.start_at.future?
+  end
+
+  def past?
+    slot.start_at.past?
   end
 
   def self.for_sms_cancellation(number)

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -26,4 +26,36 @@ RSpec.describe Appointment, 'Validation' do
       expect(appointment).not_to be_should_cancel
     end
   end
+
+  describe '#notify?' do
+    subject { create(:appointment, :with_slot) }
+
+    context 'when the status was changed' do
+      it 'handles correctly' do
+        travel_to 2.days.ago do
+          subject.update(status: :complete)
+          expect(subject).to_not be_notify
+
+          subject.update(status: :pending)
+          expect(subject).to be_notify
+        end
+      end
+
+      context 'when the appointment has elapsed' do
+        it 'is false' do
+          expect(subject).not_to be_notify
+        end
+      end
+    end
+
+    context 'when the status was not changed' do
+      it 'returns true' do
+        travel_to 2.days.ago do
+          subject.update(first_name: 'George')
+
+          expect(subject).to be_notify
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Re-sends the confirmation email when the customer details are changed by
a booking manager.