### PR TITLE
Add an activity when emailing a customer

### DIFF
--- a/app/controllers/api/v1/appointments_controller.rb
+++ b/app/controllers/api/v1/appointments_controller.rb
@@ -40,6 +40,7 @@ module Api
       end
 
       def deliver_notifications(appointment)
+        EmailActivity.from(appointment)
         AppointmentMailer.customer(appointment).deliver_later
         SlackPingerJob.perform_later(appointment)
 

--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -17,8 +17,8 @@ class AppointmentsController < ApplicationController
 
   def update
     if @appointment.update(appointment_params)
-      handle_cancellation(@appointment)
-      handle_notification(@appointment)
+      handle_cancellation(@appointment.object)
+      handle_notification(@appointment.object)
       redirect_to appointments_path, success: 'The appointment was updated.'
     else
       render :edit
@@ -57,14 +57,16 @@ class AppointmentsController < ApplicationController
 
   def handle_cancellation(appointment)
     appointment.handle_cancellation! do
-      AppointmentMailer.cancellation(appointment.object).deliver_later
+      EmailActivity.from(appointment)
+      AppointmentMailer.cancellation(appointment).deliver_later
     end
   end
 
   def handle_notification(appointment)
     return unless appointment.notify?
 
-    AppointmentMailer.customer(appointment.object).deliver_later
+    EmailActivity.from(appointment)
+    AppointmentMailer.customer(appointment).deliver_later
   end
 
   def appointment_params # rubocop:disable Metrics/MethodLength

--- a/app/controllers/reschedules_controller.rb
+++ b/app/controllers/reschedules_controller.rb
@@ -7,7 +7,7 @@ class ReschedulesController < ApplicationController
 
   def update
     if @appointment.update(appointment_params)
-      notify_customer(@appointment)
+      notify_customer(@appointment.object)
       redirect_to appointments_path, success: 'The appointment was rescheduled.'
     else
       render :edit
@@ -32,6 +32,7 @@ class ReschedulesController < ApplicationController
   end
 
   def notify_customer(appointment)
-    AppointmentMailer.customer(appointment.object).deliver_later
+    EmailActivity.from(appointment)
+    AppointmentMailer.customer(appointment).deliver_later
   end
 end

--- a/app/models/email_activity.rb
+++ b/app/models/email_activity.rb
@@ -1,0 +1,7 @@
+class EmailActivity < Activity
+  def self.from(appointment)
+    return if appointment.past?
+
+    PusherNotificationJob.perform_later(super)
+  end
+end

--- a/app/views/activities/_email_activity.html.erb
+++ b/app/views/activities/_email_activity.html.erb
@@ -1,0 +1,11 @@
+<li
+  class="activity list-group-item t-activity <%= 't-hidden-activity activity--hideable activity--hide' if hide %>"
+  data-activity-id="<%= email_activity.id %>">
+  <div class="activity__inner">
+    <span class="glyphicon glyphicon-envelope" aria-hidden="true"></span>
+    <strong>The system</strong> notified the customer by email
+    <span class="activity__date">
+      <%= email_activity.created_at.in_time_zone('London').to_s(:govuk_date_short) %> (<%= time_ago_in_words(email_activity.created_at.in_time_zone('London'))%> ago)
+    </span>
+  </div>
+</li>

--- a/app/views/appointments/_activities.html.erb
+++ b/app/views/appointments/_activities.html.erb
@@ -19,9 +19,9 @@
       </div>
 
       <ol class="list-group" aria-live="polite" data-module="activity-feed" id="activity-list" data-config='{"event": "appointment_activity_<%= appointment.id %>"}' aria-label="Activities">
-        <%= render(appointment.activities[0..2], hide: false) if appointment.activities.present? %>
+        <%= render(appointment.activities.order(created_at: :desc)[0..2], hide: false) if appointment.activities.present? %>
         <% if appointment.activities.count > 3 %>
-          <%= render(appointment.activities - Array(appointment.activities[0..2]), hide: true) %>
+          <%= render(appointment.activities.order(created_at: :desc) - Array(appointment.activities.order(created_at: :desc)[0..2]), hide: true) %>
         <% end %>
       </ol>
 

--- a/spec/features/booking_manager_manages_an_appointment_spec.rb
+++ b/spec/features/booking_manager_manages_an_appointment_spec.rb
@@ -25,11 +25,13 @@ RSpec.feature 'Booking manager manages an appointment' do
 
   scenario 'Cancelling an appointment' do
     perform_enqueued_jobs do
-      given_the_user_is_identified_as_a_booking_manager do
-        and_they_have_an_associated_appointment
-        when_the_appointment_is_cancelled
-        then_the_customer_is_notified
-        and_the_original_slot_is_still_available
+      travel_to 2.days.ago do # so the appointment is not `past?`
+        given_the_user_is_identified_as_a_booking_manager do
+          and_they_have_an_associated_appointment
+          when_the_appointment_is_cancelled
+          then_the_customer_is_notified
+          and_the_original_slot_is_still_available
+        end
       end
     end
   end
@@ -92,6 +94,8 @@ RSpec.feature 'Booking manager manages an appointment' do
   end
 
   def then_the_customer_is_notified
+    expect(@appointment.activities.first).to be_an(EmailActivity)
+
     expect(ActionMailer::Base.deliveries.first.to).to match_array(@appointment.email)
   end
   alias_method :and_the_customer_is_notified, :then_the_customer_is_notified

--- a/spec/features/booking_manager_reschedules_appointment_spec.rb
+++ b/spec/features/booking_manager_reschedules_appointment_spec.rb
@@ -85,6 +85,8 @@ RSpec.feature 'Booking manager reschedules appointment' do
   end
 
   def and_the_customer_is_notified
+    expect(@appointment.activities.first).to be_an(EmailActivity)
+
     expect(ActionMailer::Base.deliveries.first.to).to match_array(@appointment.email)
   end
 end

--- a/spec/requests/external_appointment_api_spec.rb
+++ b/spec/requests/external_appointment_api_spec.rb
@@ -86,6 +86,8 @@ RSpec.describe 'POST /api/v1/locations/:location_id/appointments' do
   end
 
   def and_the_customer_is_notified
+    expect(@appointment.activities.first).to be_an(EmailActivity)
+
     expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(@appointment.email)
   end
 


### PR DESCRIPTION
Any action that results in an email to the customer is logged in the
activity feed.