### PR TITLE
Attempt to cancel the first booked appointment

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -100,7 +100,7 @@ class Appointment < ApplicationRecord # rubocop:disable ClassLength
 
   def self.for_sms_cancellation(number)
     pending
-      .order(created_at: :desc)
+      .order(:created_at)
       .find_by("REPLACE(phone, ' ', '') = :number", number: number)
   end
 


### PR DESCRIPTION
Previously we would cancel the latest appointment by creation date.
Generally when there are duplicates, the customer's intention would be
to cancel their first booked appointment.