### PR TITLE
Include date/location in SMS cancellation

### DIFF
--- a/app/jobs/sms_cancellation_success_job.rb
+++ b/app/jobs/sms_cancellation_success_job.rb
@@ -1,13 +1,19 @@
 class SmsCancellationSuccessJob < SmsJobBase
   TEMPLATE_ID = '0222b5ca-265b-478a-ad89-b37bbad8acba'.freeze
 
-  def perform(appointment)
+  def perform(appointment) # rubocop:disable MethodLength
     return unless api_key
+
+    appointment = AppointmentDecorator.new(appointment)
 
     sms_client.send_sms(
       phone_number: appointment.phone,
       template_id: TEMPLATE_ID,
-      reference: appointment.to_param
+      reference: appointment.to_param,
+      personalisation: {
+        date: appointment.slot,
+        location: appointment.location_name
+      }
     )
   end
 end

--- a/spec/jobs/sms_cancellation_success_job_spec.rb
+++ b/spec/jobs/sms_cancellation_success_job_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe SmsCancellationSuccessJob, '#perform' do
     expect(client).to receive(:send_sms).with(
       phone_number: '07715 930 444',
       template_id: SmsCancellationSuccessJob::TEMPLATE_ID,
-      reference: appointment.to_param
+      reference: appointment.to_param,
+      personalisation: {
+        date: '2:00pm, 15 June 2018',
+        location: a_string_matching(/\ATesco \d+/)
+      }
     )
 
     described_class.new.perform(appointment)
@@ -18,9 +22,13 @@ RSpec.describe SmsCancellationSuccessJob, '#perform' do
     ENV['NOTIFY_API_KEY'] = 'blahblah'
 
     allow(Notifications::Client).to receive(:new).and_return(client)
+
+    travel_to '2018-06-15 13:00 UTC'
   end
 
   after do
     ENV.delete('NOTIFY_API_KEY')
+
+    travel_back
   end
 end


### PR DESCRIPTION
Include these details in the cancellation success message so the
customer knows exactly which appointment they have cancelled.