### PR TITLE
Remove the 'processed' column

### DIFF
--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -68,7 +68,6 @@
             <th>Location</th>
             <th>Reference</th>
             <th>Status</th>
-            <th>Processed</th>
             <th></th>
           </tr>
         </thead>
@@ -96,9 +95,6 @@
               </td>
               <td>
                 <%= appointment.status %>
-              </td>
-              <td>
-                <%= appointment.processed_at? ? 'Yes' : 'No' %>
               </td>
               <td>
                 <%= link_to(edit_appointment_path(appointment), title: 'Manage', class: 'btn btn-info t-manage') do %>


### PR DESCRIPTION
This is defaulted already so we can claim some valuable real-estate by
removing it.