### PR TITLE
Ensure the correct locations are included

### DIFF
--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -2,4 +2,14 @@ module LocationsHelper
   def location_options(scope)
     scope.order(:name).pluck(:name)
   end
+
+  def grouped_employer_locations(current_user)
+    [].tap do |data|
+      current_user.delivery_centre.employers.order(:name).each do |employer|
+        filtered_locations = employer.locations.where(id: current_user.locations.pluck(:id)).order(:name)
+
+        data << [employer.name, filtered_locations.pluck(:name, :id)]
+      end
+    end
+  end
 end

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -19,7 +19,7 @@
           </li>
           <li class="filters__item">
             <%= f.label :location, class: 'filters__label' %>
-            <%= f.grouped_collection_select :location, employers, :locations, :name, :id, :name, { include_blank: 'All Locations' }, { class: 'js-locations t-location form-control filters__form-control filters__form-control--location' } %>
+            <%= f.select :location, grouped_options_for_select(grouped_employer_locations(current_user)), { include_blank: 'All Locations' }, { class: 'js-locations t-location form-control filters__form-control filters__form-control--location' } %>
           </li>
           <li class="filters__item">
            <%= f.button class: 't-submit btn btn-default filters__button' do %>


### PR DESCRIPTION
We need to filter the locations based on the current user's granted
access. Previously this would display all locations assigned to the
employer regardless whether the current user was permitted to see them.