### PR TITLE
Manage employers

### DIFF
--- a/app/controllers/admin/employers_controller.rb
+++ b/app/controllers/admin/employers_controller.rb
@@ -1,0 +1,36 @@
+module Admin
+  class EmployersController < ApplicationController
+    before_action :authorise_administrator!
+    before_action :load_delivery_centres, except: :index
+
+    def index
+      @employers = Employer.order(:name).page(params[:page])
+    end
+
+    def new
+      @employer = Employer.new
+    end
+
+    def create
+      @employer = Employer.new(employer_params)
+
+      if @employer.save
+        CloudflareEmployerRedirectJob.perform_later(@employer)
+
+        redirect_to admin_employers_path, success: 'The employer was created'
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def load_delivery_centres
+      @delivery_centres = DeliveryCentre.order(:name)
+    end
+
+    def employer_params
+      params.require(:employer).permit(:name, :url, delivery_centre_ids: [])
+    end
+  end
+end

--- a/app/jobs/cloudflare_employer_redirect_job.rb
+++ b/app/jobs/cloudflare_employer_redirect_job.rb
@@ -1,0 +1,21 @@
+class CloudflareEmployerRedirectJob < ApplicationJob
+  queue_as :default
+
+  def perform(employer)
+    return unless bearer_token && zone_id
+
+    CloudflareForwarding
+      .new(bearer_token, zone_id)
+      .call(employer)
+  end
+
+  private
+
+  def bearer_token
+    ENV['CLOUDFLARE_BEARER_TOKEN']
+  end
+
+  def zone_id
+    ENV['CLOUDFLARE_ZONE_ID']
+  end
+end

--- a/app/lib/cloudflare_forwarding.rb
+++ b/app/lib/cloudflare_forwarding.rb
@@ -1,0 +1,61 @@
+require 'faraday'
+require 'faraday/conductivity'
+
+class CloudflareForwarding
+  def initialize(bearer_token, zone_id)
+    @bearer_token = bearer_token
+    @zone_id = zone_id
+  end
+
+  def call(employer)
+    connection.post do |request|
+      request.body = json_payload(employer)
+    end
+  end
+
+  private
+
+  def json_payload(employer) # rubocop:disable MethodLength
+    {
+      targets: [
+        target: 'url',
+        constraint: {
+          operator: 'matches',
+          value: "https://www.pensionwise.gov.uk/#{employer.url}"
+        }
+      ],
+      actions: [
+        id: 'forwarding_url',
+        value: {
+          url: "https://www.pensionwise.gov.uk/en/employers/#{employer.id}/locations",
+          status_code: 301 # Permanent Redirect
+        }
+      ],
+      priority: 10,
+      status: 'active'
+    }
+  end
+
+  def connection
+    @connection ||= Faraday.new(connection_options) do |faraday|
+      faraday.request  :json
+      faraday.response :raise_error
+      faraday.use      :instrumentation
+      faraday.adapter  Faraday.default_adapter
+      faraday.authorization :Bearer, bearer_token
+    end
+  end
+
+  def connection_options
+    {
+      url: "https://api.cloudflare.com/client/v4/zones/#{zone_id}/pagerules",
+      request: {
+        timeout: Integer(ENV.fetch('CLOUDFLARE_TIMEOUT', 2)),
+        open_timeout: Integer(ENV.fetch('CLOUDFLARE_OPEN_TIMEOUT', 2))
+      }
+    }
+  end
+
+  attr_reader :bearer_token
+  attr_reader :zone_id
+end

--- a/app/models/employer.rb
+++ b/app/models/employer.rb
@@ -3,4 +3,7 @@ class Employer < ApplicationRecord
   has_many :assignments, dependent: :destroy
 
   has_many :delivery_centres, through: :assignments
+
+  validates :name, presence: true
+  validates :url, presence: true, format: { with: /\A[a-z-]+\z/ }
 end

--- a/app/views/admin/employers/index.html.erb
+++ b/app/views/admin/employers/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for(:page_title, 'Manage Employers') %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><%= link_to 'Employer planner', root_path %></li>
+    <li class="active">Employers</li>
+  </ol>
+
+  <h1>Manage Employers</h1>
+  <%= link_to 'New employer', new_admin_employer_path, class: 'btn btn-default' %>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <% if @employers.empty? %>
+      <p class="no-content t-notice">No employers.</p>
+    <% else %>
+      <%= paginate @employers %>
+
+      <table class="table table-bordered centred-table table-striped">
+        <caption><span class="sr-only">Employers</span></caption>
+        <thead>
+          <tr class="table-header">
+            <th>Name</th>
+            <th>URL</th>
+            <th>Delivery Centres</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @employers.each do |employer| %>
+            <tr class="t-employer">
+              <td class="t-name">
+                <%= employer.name %>
+              </td>
+              <td class="t-url">
+                <%= employer.url %>
+              </td>
+              <td class="t-delivery-centres">
+                <%= employer.delivery_centres.pluck(:name).to_sentence %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+
+      <%= paginate @employers %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/employers/new.html.erb
+++ b/app/views/admin/employers/new.html.erb
@@ -1,0 +1,52 @@
+<% content_for(:page_title, t('service.title', page_title: 'New employer')) %>
+<div class="page-header">
+  <ol class="breadcrumb">
+    <li><a href="<%= root_path %>">Employer planner</a></li>
+    <li><a href="<%= admin_employers_path %>">Manage employers</a></li>
+    <li class="active">New employer</li>
+  </ol>
+
+  <h1>New employer</h1>
+</div>
+
+<%= form_for @employer, url: admin_employers_path do |f| %>
+  <div class="row">
+    <div class="col-md-6">
+      <% if @employer.errors.any? %>
+        <div class="alert alert-danger t-errors" role="alert">
+          <h3 class="alert__heading h4">There's a problem</h3>
+          <ul>
+            <% @employer.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-6">
+      <div class="form-group">
+        <%= f.label :name %>
+        <%= f.text_field :name, class: 'form-control t-name' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :url %>
+        <%= f.text_field :url, class: 'form-control t-url', placeholder: 'the-name-without-leading-slash' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :delivery_centres %>
+        <%= f.collection_select :delivery_centre_ids, @delivery_centres, :id, :name, {}, { multiple: true, class: 'form-control t-delivery-centres' } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-6">
+      <%= f.button class: 'btn btn-primary t-submit' do %>
+        Create employer
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
         <span class="caret"></span>
       </a>
       <ul class="dropdown-menu">
+        <li><%= link_to 'Employers', admin_employers_path %></li>
         <li><%= link_to 'Locations', admin_locations_path %></li>
         <li><%= link_to 'Delivery Centres', admin_delivery_centres_path %></li>
       </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do # rubocop:disable BlockLength
   end
 
   namespace :admin do
+    resources :employers, only: %i[index new create]
     resources :delivery_centres
     resources :locations do
       resources :rooms

--- a/db/migrate/20200122124748_add_url_to_employers.rb
+++ b/db/migrate/20200122124748_add_url_to_employers.rb
@@ -1,0 +1,5 @@
+class AddUrlToEmployers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :employers, :url, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_23_140319) do
+ActiveRecord::Schema.define(version: 2020_01_22_124748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2019_04_23_140319) do
     t.string "name", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "url", default: "", null: false
   end
 
   create_table "locations", force: :cascade do |t|

--- a/spec/factories/employers.rb
+++ b/spec/factories/employers.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :employer do
     sequence(:name) { |n| "Employer #{n}" }
+
+    url { 'employer-url-fragment' }
   end
 end

--- a/spec/features/administrator_creates_an_employer_spec.rb
+++ b/spec/features/administrator_creates_an_employer_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing employers' do
+  scenario 'Administrator creates an employer' do
+    given_the_user_is_identified_as_an_administrator do
+      and_a_delivery_centre_exists
+      when_the_administrator_creates_an_employer
+      then_the_employer_is_created
+      and_the_cloudflare_redirect_is_enqueued
+    end
+  end
+
+  def and_a_delivery_centre_exists
+    @dc = create(:delivery_centre)
+  end
+
+  def when_the_administrator_creates_an_employer
+    @page = Pages::Admin::Employer.new
+    @page.load
+
+    @page.name.set 'An Employer'
+    @page.url_fragment.set 'an-employer'
+    @page.delivery_centres.select @dc.name
+
+    @page.submit.click
+  end
+
+  def then_the_employer_is_created
+    @page = Pages::Admin::Employers.new
+    expect(@page).to be_displayed
+    expect(@page).to have_success
+
+    expect(@page).to have_employers
+    expect(@page.employers.first.name).to have_text('An Employer')
+    expect(@page.employers.first.url).to have_text('an-employer')
+    expect(@page.employers.first.delivery_centres).to have_text(@dc.name)
+  end
+
+  def and_the_cloudflare_redirect_is_enqueued
+    assert_enqueued_jobs(1, only: CloudflareEmployerRedirectJob)
+  end
+end

--- a/spec/models/employer_spec.rb
+++ b/spec/models/employer_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Employer do
+  it 'is valid with valid attributes' do
+    expect(build(:employer)).to be_valid
+  end
+
+  it 'requires a valid url' do
+    expect(build(:employer, url: '/a')).to be_invalid
+  end
+end

--- a/spec/support/pages/admin/employer.rb
+++ b/spec/support/pages/admin/employer.rb
@@ -1,0 +1,13 @@
+module Pages
+  module Admin
+    class Employer < SitePrism::Page
+      set_url '/admin/employers/new'
+
+      element :name, '.t-name'
+      element :url_fragment, '.t-url'
+      element :delivery_centres, '.t-delivery-centres'
+
+      element :submit, '.t-submit'
+    end
+  end
+end

--- a/spec/support/pages/admin/employers.rb
+++ b/spec/support/pages/admin/employers.rb
@@ -1,0 +1,15 @@
+module Pages
+  module Admin
+    class Employers < SitePrism::Page
+      set_url '/admin/employers'
+
+      element :success, '.alert-success'
+
+      sections :employers, '.t-employer' do
+        element :name, '.t-name'
+        element :url, '.t-url'
+        element :delivery_centres, '.t-delivery-centres'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Can now create and assign employers/delivery centres. Upon successful
creation a cloudflare redirect will be created from the `url` to the
correct location on the customer front end.