### PR TITLE
Only return actual booking managers

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -88,7 +88,7 @@ class Appointment < ApplicationRecord # rubocop:disable ClassLength
   end
 
   def booking_managers
-    delivery_centre.users.active
+    delivery_centre.users.active.select(&:booking_manager?)
   end
 
   def cancelled?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     factory :administrator do
       permissions { %w[signin booking_manager administrator] }
     end
+
+    factory :orphaned_user do
+      permissions { %w[signin] }
+    end
   end
 end

--- a/spec/models/appointment_spec.rb
+++ b/spec/models/appointment_spec.rb
@@ -1,6 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Appointment, 'Validation' do
+  describe '#booking_managers' do
+    it 'does not include regular, permissionless users' do
+      appointment = create(:appointment, :with_slot)
+      # this will not appear as it has no `booking_manager` permission
+      create(:orphaned_user, delivery_centre: appointment.delivery_centre)
+
+      expect(appointment.booking_managers).to be_empty
+
+      # this will appear as it has the right permission
+      create(:user, delivery_centre: appointment.delivery_centre)
+
+      expect(appointment.booking_managers).not_to be_empty
+    end
+  end
+
   %i[
     cancelled_by_customer
     cancelled_by_pension_wise

--- a/spec/requests/external_location_api_spec.rb
+++ b/spec/requests/external_location_api_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'GET /api/v1/locations/:location_id' do
   end
 
   def then_the_service_responds_with_a_404
-    expect(response).to be_missing
+    expect(response).to be_not_found
   end
 
   def given_the_location_exists


### PR DESCRIPTION
This was returning all users as long as they were active. There are cases
where a user can be active but is no longer granted the specific
`booking_manager` permission so we have to ensure they are excluded.