### PR TITLE
Redact customer data

### DIFF
--- a/app/lib/redactor.rb
+++ b/app/lib/redactor.rb
@@ -1,0 +1,46 @@
+class Redactor
+  def initialize(reference)
+    @reference = reference
+  end
+
+  def call
+    return unless appointment = Appointment.find(reference) # rubocop:disable AssignmentInCondition
+
+    ActiveRecord::Base.transaction do
+      Appointment.without_auditing do
+        redact_appointment(appointment)
+        redact_audits(appointment)
+        redact_activities(appointment)
+      end
+    end
+  end
+
+  def self.redact_for_gdpr
+    Appointment.for_redaction.pluck(:id).each do |reference|
+      new(reference).call
+    end
+  end
+
+  private
+
+  def redact_appointment(appointment)
+    appointment.update(
+      first_name: 'redacted',
+      last_name: 'redacted',
+      email: 'redacted@example.com',
+      phone: '00000000000',
+      date_of_birth: '1950-01-01',
+      memorable_word: 'redacted'
+    )
+  end
+
+  def redact_audits(appointment)
+    appointment.audits.delete_all
+  end
+
+  def redact_activities(appointment)
+    appointment.activities.delete_all
+  end
+
+  attr_reader :reference
+end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -114,6 +114,12 @@ class Appointment < ApplicationRecord # rubocop:disable ClassLength
     slot.start_at.past?
   end
 
+  def self.for_redaction
+    where
+      .not(first_name: 'redacted')
+      .where('created_at < ?', 2.years.ago.beginning_of_day)
+  end
+
   def self.for_sms_cancellation(number)
     pending
       .order(:created_at)

--- a/lib/tasks/confidentiality.rake
+++ b/lib/tasks/confidentiality.rake
@@ -1,0 +1,11 @@
+namespace :confidentiality do
+  desc 'Redact customer details from an appointment reference REFERENCE'
+  task redact: :environment do
+    Redactor.new(ENV.fetch('REFERENCE')).call
+  end
+
+  desc 'Redact records older than 2 years'
+  task gdpr: :environment do
+    Redactor.redact_for_gdpr
+  end
+end

--- a/spec/lib/redactor_spec.rb
+++ b/spec/lib/redactor_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Redactor do
+  describe '.redact_for_gdpr' do
+    it 'redacts records yet to be redacted, greater than 2 years old' do
+      travel_to '2018-02-28 10:00' do
+        @redacted = create(:appointment, :with_slot, first_name: 'redacted')
+        @included = create(:appointment, :with_slot)
+      end
+
+      travel_to '2020-01-01 10:00' do
+        @excluded = create(:appointment, :with_slot)
+      end
+
+      travel_to '2020-03-31 10:00' do
+        described_class.redact_for_gdpr
+      end
+
+      # was redacted
+      expect(@included.reload.created_at).not_to eq(@included.updated_at)
+      # was already redacted so not updated
+      expect(@redacted.reload.created_at).to eq(@redacted.updated_at)
+      # was outside the date range so not updated
+      expect(@excluded.reload.created_at).to eq(@excluded.updated_at)
+    end
+  end
+
+  describe '#call' do
+    it 'redacts all personally identifying information' do
+      appointment = create(:appointment, :with_slot)
+      redactor    = described_class.new(appointment.id)
+
+      redactor.call
+
+      expect(appointment.reload).to have_attributes(
+        first_name: 'redacted',
+        last_name: 'redacted',
+        email: 'redacted@example.com',
+        phone: '00000000000',
+        date_of_birth: '1950-01-01'.to_date,
+        memorable_word: 'redacted'
+      )
+
+      expect(appointment.audits).to be_empty
+      expect(appointment.activities).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Allows customer data to be redacted on an individual appointment basis,
or for GDPR compliance on records older than two years.